### PR TITLE
Make CI buildable on macos-latest runner image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   test-macos:
-    name: Test (macOS, Xcode 26.4)
+    name: Test (macOS, Xcode 26.3)
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Select Xcode 26.4
-        run: sudo xcode-select -s /Applications/Xcode_26.4.app
+      - name: Select Xcode 26.3
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app
       - name: Run tests
         run: ./script/test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,10 +24,16 @@ satisfy when they're created, not a map of what already exists.
 
 ## Toolchain
 
-- **Floor: Xcode 26.4+ / Swift 6.x.** Brand-new project, audience is Justin,
-  latest toolchain only. No accommodations for older Xcode or Swift versions.
-  Use macros, swift-testing, strict concurrency, and any other modern
-  features without apology.
+- **Local floor: Xcode 26.4+ / Swift 6.x.** Brand-new project, audience is
+  Justin, latest toolchain only. No accommodations for older Xcode or Swift
+  versions. Use macros, swift-testing, strict concurrency, and any other
+  modern features without apology.
+- **CI floor: whatever's on `macos-latest`.** GitHub's hosted runner image
+  lags Apple releases by a few weeks. Pin CI to the newest Xcode the runner
+  ships (currently 26.3); deployment targets in `Package.swift` must stay
+  buildable against that runner's SDK ceiling (currently 26.2). Bump both
+  in lockstep when the runner image catches up — the local floor can move
+  faster, but the package itself stays buildable on CI.
 
 ## Platforms
 
@@ -133,8 +139,9 @@ it doesn't gate where the package builds.
 ## CI
 
 - **GitHub Actions.** Workflows live in `.github/workflows/`.
-- **Matrix:** `macOS-latest` (Xcode 26.4), one Swift version. Linux is
-  not built (see Platforms above).
+- **Matrix:** `macOS-latest` (Xcode 26.3 — newest available on the runner
+  image; see Toolchain), one Swift version. Linux is not built (see
+  Platforms above).
 - Workflows invoke `script/test` rather than duplicating commands — the
   script is the single source of truth for what "pass" means locally and in
   CI.

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.2
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -4,11 +4,11 @@ import PackageDescription
 let package = Package(
   name: "Splint",
   platforms: [
-    .iOS("26.4"),
-    .macOS("26.4"),
-    .tvOS("26.4"),
-    .watchOS("26.4"),
-    .visionOS("26.4"),
+    .iOS("26.2"),
+    .macOS("26.2"),
+    .tvOS("26.2"),
+    .watchOS("26.2"),
+    .visionOS("26.2"),
   ],
   products: [
     .library(name: "Splint", targets: ["Splint"])


### PR DESCRIPTION
## Summary

CI is failing on `claude/epic-mayer` (and would fail on every branch) because `Xcode_26.4.app` isn't on GitHub's `macos-latest` runner yet — the newest there is 26.3, and the SDK ceiling is macOS 26.2. This PR makes the package buildable on the runner without giving up the latest-toolchain stance for local development.

## Changes

- **`.github/workflows/ci.yml`**: pin to `Xcode_26.3.app` (newest available on `macos-latest`).
- **`Package.swift`**: lower platform deployment targets from `26.4` to `26.2` so the package builds against the runner's SDK ceiling. The library code itself uses no 26.4-specific APIs as far as I could see.
- **`CLAUDE.md`**: document the local-vs-CI version split. Local floor remains Xcode 26.4+ / Swift 6.x; CI floor tracks `macos-latest`. Future bumps should move both in lockstep when the runner image catches up.

## Why not self-hosted

We considered a self-hosted runner with Xcode 26.4. No runner was registered for the repo and standing one up wasn't worth the infrastructure cost given that the package doesn't actually need 26.4-only APIs today.

## Test plan

- [x] `script/test` — 60/60 tests pass locally on Xcode 26.4 with the lowered deployment targets
- [ ] CI run on this PR confirms 26.3 + macOS 26.2 SDK build is green
- [ ] After merge, rebase or cherry-pick into `claude/epic-mayer` (#6) so that PR's CI clears too

## Caveats

Local Xcode 26.4 is *newer* than the CI's 26.3, so a local pass doesn't catch a hypothetical 26.4-only API leak. Pushing this and watching the CI run is the only definitive proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)