### PR TITLE
Document Lens closure capture semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,9 @@ init(client: BookClient) {
 }
 ```
 
-No singletons, no late-binding, no service locators.
+No singletons, no late-binding, no service locators. The same rule
+applies to `Lens` filter/sort closures — see "Lens closures capture
+once" below.
 
 ## Narrowly-scoped catalogs over client-side filtering
 
@@ -246,6 +248,33 @@ items change — O(n) where n is the source size. Under ~1k items this is
 negligible. For larger datasets, consider whether filtering belongs in
 the fetch closure (server-side filtering via `Criteria`) rather than in
 a client-side `Lens`.
+
+## Lens closures capture once
+
+`Lens` captures `filter` and `sort` at init. They re-run only on
+`updateFilter` / `updateSort` — not when variables they reference
+change. Capturing mutable view state at init compiles and looks
+correct, and fails silently:
+
+```swift
+// ❌ minRating capture goes stale — Lens never sees changes
+@State private var minRating = 0
+@State private var lens = Lens(source: catalog, filter: { $0.rating >= minRating })
+
+// ✅ Drive updates explicitly
+@State private var minRating = 0
+@State private var lens = Lens(source: catalog)
+
+var body: some View {
+    BookListView(lens: lens)
+        .onChange(of: minRating) { _, new in
+            lens.updateFilter { $0.rating >= new }
+        }
+}
+```
+
+Same rule as `Catalog`'s fetch closure: Splint closures capture at
+construction; mutable inputs flow through update methods.
 
 ## Session coordination
 

--- a/Sources/Splint/Lens.swift
+++ b/Sources/Splint/Lens.swift
@@ -22,7 +22,11 @@ public final class Lens<Item: Resource> {
   @ObservationIgnored private var order: (@Sendable (Item, Item) -> Bool)?
   public init<Criteria: Equatable & Sendable>(
     source: Catalog<Item, Criteria>,
+    /// Predicate applied to each item. Captured once at init; re-runs only
+    /// when `updateFilter` is called. Do not capture mutable view state —
+    /// drive `updateFilter` from `.onChange(of:)` instead.
     filter: @escaping @Sendable (Item) -> Bool = { _ in true },
+    /// Comparator applied after filtering. Same capture rules as `filter`.
     sort: (@Sendable (Item, Item) -> Bool)? = nil
   ) {
     self.sourceItems = { source.items }

--- a/claude/rules/splint.md
+++ b/claude/rules/splint.md
@@ -12,7 +12,9 @@ inventing a new type.
   Criteria is always an `Equatable & Sendable` struct — even a single-field
   one. For the genuinely parameter-free case, `Catalog<Item, NoCriteria>`.
 - **Filtered or sorted view** over a Catalog → `Lens<Item>`. It derives;
-  it does not fetch. Multiple lenses can share one catalog.
+  it does not fetch. Multiple lenses can share one catalog. Filter/sort
+  closures capture once at construction — drive mutable filter inputs
+  through `updateFilter`/`updateSort` from `.onChange(of:)`.
 - **Async operation lifecycle** (a fetch, a save, a one-off call) →
   `Job<Value>`. Not `isLoading` + `error` + `data` as separate booleans.
 - **Selected item identifier** → `Selection<ID>`. One per selectable


### PR DESCRIPTION
## Summary

- Closes #4. `Lens` filter/sort closures are captured at init and only re-run on `updateFilter`/`updateSort`; capturing mutable view state compiles but silently goes stale. This PR documents the rule without changing the API.
- Init-param doc comments on `Lens.init` (`Sources/Splint/Lens.swift`), a new "Lens closures capture once" README section with an ❌/✅ `minRating` example, a cross-reference from the Catalog lifecycle closure-capture paragraph, and a one-line note appended to the Lens bullet in `claude/rules/splint.md`.
- No change needed in the Bookshelf example — `BookListView` already uses `.onChange(of: query)` to drive `updateFilter`, and `ContentView` constructs both lenses without capturing mutable state.

## Test plan

- [x] `swift build` clean
- [x] `./script/test` — 60 tests across 7 suites pass
- [ ] Skim rendered README on GitHub to confirm the new section and ❌/✅ code block render correctly
- [ ] Confirm DocC picks up the new init-parameter docs when building docs locally (`script/docs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)