### PR TITLE
Document and dogfood `sending` on Job.run

### DIFF
--- a/Example/Bookshelf/BookDetailView.swift
+++ b/Example/Bookshelf/BookDetailView.swift
@@ -68,8 +68,14 @@ public struct BookDetailView: View {
   }
 
   private func runMetadata() {
-    let id = book.id
-    let client = client
-    metadataJob.run { try await client.fetchMetadata(id) }
+    // `Job.run`'s `task:` is `sending` — region-based isolation accepts
+    // the closure's disconnected copy of `self` even though
+    // `BookDetailView` is not `Sendable` (it holds `@Query`,
+    // `@Environment`, and `@State` property wrappers that aren't).
+    // Under `@Sendable` this would fail to compile. We only read stable
+    // `let` properties (`client`, `book`) — reaching into view state
+    // (`@Query` results, mutating `@State`, etc.) from inside the Task
+    // would still be wrong. See README "Job closures and isolation".
+    metadataJob.run { try await client.fetchMetadata(book.id) }
   }
 }

--- a/README.md
+++ b/README.md
@@ -291,12 +291,22 @@ Capture whatever's needed — a `Sendable` service, `self`'s init-time
 `let` properties, a value-type input. What to avoid inside the closure
 body:
 
-- Reading or mutating `@State`, `@Query` results, or `@Environment`
-  values. Those wrappers are `@MainActor`-isolated; the closure runs
-  in the `Task`'s own isolation region.
-- Assuming the `Task` runs on the main actor — it does not. Hop back
-  with `await MainActor.run { ... }` if you need to mutate `@MainActor`
-  state after the await point.
+- Reading `@State`, `@Query` results, or `@Environment` values from
+  inside the closure body. Even when the capture compiles, you get a
+  frozen snapshot taken when the closure was created — later wrapper
+  updates are invisible. Capture the specific IDs or scalars you need
+  at the call site instead.
+- Mutating `@MainActor` state directly. The `Task` runs off the main
+  actor, so the compiler usually blocks this. When you genuinely need
+  to mutate main-actor state after the `await`, hop back explicitly:
+
+```swift
+metadataJob.run {
+    let fresh = try await client.fetchMetadata(book.id)
+    await MainActor.run { cache[book.id] = fresh }
+    return fresh
+}
+```
 
 ```swift
 // ✅ Capture self; read stable init-time `let` properties.
@@ -311,8 +321,10 @@ body:
     metadataJob.run { try await client.fetchMetadata(id) }
 }
 
-// ❌ Reads @Query / @State inside the Task — wrong isolation region,
-// stale reads at best, compile errors at worst.
+// ❌ Reads @Query results inside the Task. `sending` may allow the
+// capture, but `favorites` is a snapshot frozen at closure creation —
+// later @Query updates never reach this closure. Pull what you need
+// out at the call site and pass it in as a scalar.
 .task {
     metadataJob.run {
         let fav = favorites.contains { $0.bookID == book.id }

--- a/README.md
+++ b/README.md
@@ -278,6 +278,49 @@ var body: some View {
 Same rule as `Catalog`'s fetch closure: Splint closures capture at
 construction; mutable inputs flow through update methods.
 
+## Job closures and isolation
+
+`Job.run`'s task closure runs in its own `Task`. Because `task:` is
+`sending` ([SE-0430](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0430-transferring-parameters-and-results.md)),
+the closure can capture non-`Sendable` values at the call site —
+including `self` of a SwiftUI `View`, whose property wrappers usually
+make the enclosing struct non-`Sendable`. Region-based isolation
+accepts the closure's disconnected copy of the captured values.
+
+Capture whatever's needed — a `Sendable` service, `self`'s init-time
+`let` properties, a value-type input. What to avoid inside the closure
+body:
+
+- Reading or mutating `@State`, `@Query` results, or `@Environment`
+  values. Those wrappers are `@MainActor`-isolated; the closure runs
+  in the `Task`'s own isolation region.
+- Assuming the `Task` runs on the main actor — it does not. Hop back
+  with `await MainActor.run { ... }` if you need to mutate `@MainActor`
+  state after the await point.
+
+```swift
+// ✅ Capture self; read stable init-time `let` properties.
+.task {
+    metadataJob.run { try await client.fetchMetadata(book.id) }
+}
+
+// ✅ Equivalent; explicit capture for readability.
+.task {
+    let client = client
+    let id = book.id
+    metadataJob.run { try await client.fetchMetadata(id) }
+}
+
+// ❌ Reads @Query / @State inside the Task — wrong isolation region,
+// stale reads at best, compile errors at worst.
+.task {
+    metadataJob.run {
+        let fav = favorites.contains { $0.bookID == book.id }
+        return try await client.fetchMetadata(for: book.id, favorited: fav)
+    }
+}
+```
+
 ## Session coordination
 
 Login, logout, and reauthentication require atomic coordination across

--- a/Sources/Splint/Job.swift
+++ b/Sources/Splint/Job.swift
@@ -21,9 +21,21 @@ public final class Job<Value: Sendable> {
 
   public init() {}
 
-  /// Run `task`. Cancels any in-flight work. Phase transitions to
+  /// Run an async operation, transferring its result into the Job's
+  /// ``value``.
+  ///
+  /// Cancels any in-flight work. ``phase`` transitions to
   /// ``Phase/running`` immediately, then ``Phase/completed`` or
   /// ``Phase/failed(_:)`` when `task` resolves.
+  ///
+  /// The `task` closure is marked `sending` rather than `@Sendable`.
+  /// This uses region-based isolation (Swift 6.0+) to let the closure
+  /// capture non-`Sendable` values — like `@MainActor`-isolated
+  /// services or view state — at the call site, as long as those
+  /// values are in a disconnected isolation region when `run` is
+  /// called. In practice: capture what you need once, do not also
+  /// reference it from elsewhere after passing it in. See
+  /// [SE-0430](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0430-transferring-parameters-and-results.md).
   public func run(
     priority: TaskPriority? = nil,
     task: sending @escaping () async throws -> Value

--- a/Tests/SplintTests/JobTests.swift
+++ b/Tests/SplintTests/JobTests.swift
@@ -11,6 +11,21 @@ extension Boom: LocalizedError {
   var errorDescription: String? { msg }
 }
 
+/// Intentionally non-`Sendable`: a reference type with a mutable stored
+/// property and no `Sendable` conformance. Under `@Sendable` this could
+/// not be captured by `Job.run`'s closure; `sending` transfers it safely.
+private final class NonSendableBox {
+  var value: Int = 42
+}
+
+/// A small `@MainActor`-isolated service, mirroring the real-world
+/// pattern of a view capturing an `@Environment` client and handing it
+/// to `Job.run`.
+@MainActor
+private final class FakeMainActorService {
+  func fetch() -> Int { 7 }
+}
+
 @MainActor
 @Suite("Job")
 struct JobTests {
@@ -126,5 +141,29 @@ struct JobTests {
     }
     #expect(job.value == 1)
     #expect(job.phase == .failed("later"))
+  }
+
+  /// Compile-guard for SE-0430: the `task:` parameter is `sending`, not
+  /// `@Sendable`. A non-`Sendable` reference captured into the closure
+  /// must compile here. This test would fail to compile if anyone
+  /// reverted `sending` → `@Sendable` on ``Job/run(priority:task:)``.
+  @Test func runAcceptsClosureCapturingNonSendableValue() async {
+    let box = NonSendableBox()
+    let job = Job<Int>()
+    job.run { box.value }
+    await waitUntil { job.phase == .completed }
+    #expect(job.value == 42)
+  }
+
+  /// Compile-guard for SE-0430: a `@MainActor`-isolated service
+  /// (analogous to an `@Environment` client in a SwiftUI view) can be
+  /// captured by the `sending` closure. Under `@Sendable` the capture
+  /// would fail — `FakeMainActorService` is not `Sendable`.
+  @Test func runAcceptsClosureCapturingMainActorService() async {
+    let service = FakeMainActorService()
+    let job = Job<Int>()
+    job.run { await service.fetch() }
+    await waitUntil { job.phase == .completed }
+    #expect(job.value == 7)
   }
 }

--- a/Tests/SplintTests/JobTests.swift
+++ b/Tests/SplintTests/JobTests.swift
@@ -145,9 +145,11 @@ struct JobTests {
 
   /// Compile-guard for SE-0430: the `task:` parameter is `sending`, not
   /// `@Sendable`. A non-`Sendable` reference captured into the closure
-  /// must compile here. This test would fail to compile if anyone
-  /// reverted `sending` → `@Sendable` on ``Job/run(priority:task:)``.
-  @Test func runAcceptsClosureCapturingNonSendableValue() async {
+  /// must compile here. The `#expect` is incidental — the load-bearing
+  /// assertion is that this file compiles at all. Reverting `sending` →
+  /// `@Sendable` on ``Job/run(priority:task:)`` would break compilation.
+  @Test("compile-guard: closure may capture non-Sendable value (sending)")
+  func compileGuardNonSendableCapture() async {
     let box = NonSendableBox()
     let job = Job<Int>()
     job.run { box.value }
@@ -157,9 +159,12 @@ struct JobTests {
 
   /// Compile-guard for SE-0430: a `@MainActor`-isolated service
   /// (analogous to an `@Environment` client in a SwiftUI view) can be
-  /// captured by the `sending` closure. Under `@Sendable` the capture
-  /// would fail — `FakeMainActorService` is not `Sendable`.
-  @Test func runAcceptsClosureCapturingMainActorService() async {
+  /// captured by the `sending` closure. The `#expect` is incidental —
+  /// the load-bearing assertion is that this file compiles.
+  /// `FakeMainActorService` is not `Sendable`; under `@Sendable` the
+  /// capture would fail.
+  @Test("compile-guard: closure may capture @MainActor service (sending)")
+  func compileGuardMainActorCapture() async {
     let service = FakeMainActorService()
     let job = Job<Int>()
     job.run { await service.fetch() }


### PR DESCRIPTION
## Summary

- Expand DocC on `Job.run` to explain why `task:` is `sending` rather than `@Sendable`, with a link to [SE-0430](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0430-transferring-parameters-and-results.md).
- Add a new README section, **Job closures and isolation**, with ✅/❌ examples covering safe `self` capture and the `@State` / `@Query` / `@Environment` anti-pattern inside the Task body.
- Add two compile-guard tests to `JobTests`: one captures a non-`Sendable` reference, one captures a `@MainActor` service. Both would fail to compile if `sending` → `@Sendable` regressed.
- Rewrite `BookDetailView.runMetadata()` to capture `self` implicitly — `BookDetailView` is not `Sendable` (holds `@Query`, `@Environment`, `@State` wrappers), so this is the load-bearing dogfood of `sending` in the example app.

## Why

The signature already used `sending`, but nothing explained it and nothing in our own code actually required it — the example's defensive `let client = client` would have compiled under `@Sendable` too. The migration was invisible.

## Test plan

- [x] `./script/test` — 62 tests pass, 100% line coverage on `Sources/Splint/`
- [x] `cd Example && swift build` — clean
- [x] `cd Example && swift test` — 10/10 integration tests pass
- [x] New tests `runAcceptsClosureCapturingNonSendableValue` and `runAcceptsClosureCapturingMainActorService` pass
- [x] `BookDetailView` implicit-`self` rewrite compiles under Swift 6.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)