### PR TITLE
Sync Setting instances on the same key via UserDefaults KVO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Agent rules at `claude/rules/splint.md`.
 - README install instructions for dropping `claude/rules/splint.md`
   into a consuming project via `curl`.
+- `Setting` now observes its key via `UserDefaults` KVO. Multiple
+  `Setting` instances bound to the same key/store stay in sync
+  automatically, and App Group suites stay in sync across the host
+  app and its extensions via `userdefaultsd`.
+
+### Changed
+
+- `SettingValue` now requires `Equatable` (in addition to `Sendable`).
+  Every built-in conformer is already `Equatable`, so existing
+  conformances continue to work; user-defined conformers must add it.

--- a/README.md
+++ b/README.md
@@ -288,6 +288,21 @@ on the authenticated root view and destroyed on logout. Splint types
 (`Credential`, `Setting`, `Catalog`) are the *fields* it coordinates,
 not a replacement for the coordinator itself.
 
+## Settings sync across instances and processes
+
+`Setting` observes its key via `UserDefaults` key-value observation, so:
+
+- **Multiple instances on the same key stay in sync.** Two `Setting`s
+  bound to the same key/store see each other's writes automatically.
+  No "single owner per key" convention required — instance count is a
+  perf footnote, not a correctness concern.
+- **App Group suites sync across processes.** A `Setting` backed by
+  `UserDefaults(suiteName: "group.example.shared")` stays in sync
+  between the host app and its extensions (widgets, intents, share
+  extensions). This is Apple's `userdefaultsd` behavior for
+  entitlement-granted App Groups, surfaced through standard KVO —
+  Splint adds no code of its own for cross-process notification.
+
 ## What Splint won't fix
 
 Splint addresses data structure. It does not address SwiftUI rendering

--- a/Sources/Splint/Setting.swift
+++ b/Sources/Splint/Setting.swift
@@ -55,21 +55,7 @@ public final class Setting<Value: SettingValue> {
     self.write = write
     self.value = read(store, key) ?? defaultValue
     self.observer = SettingObserver()
-    // All stored properties are now initialized; safe to capture
-    // `self` and register with the store.
-    self.observer.onChange = { [weak self] in
-      // KVO fires on whatever thread performed the write (or a
-      // background queue for cross-process `userdefaultsd`
-      // callbacks), so we always hop to the main actor.
-      DispatchQueue.main.async {
-        MainActor.assumeIsolated {
-          self?._applyExternalChange()
-        }
-      }
-    }
-    // Do NOT pass `.initial` — `init` already seeded `value` by
-    // reading the store directly above.
-    store.addObserver(self.observer, forKeyPath: key, options: [.new], context: nil)
+    installObserver()
   }
 
   /// Internal designated init used by the `RawRepresentable` extension.
@@ -88,21 +74,32 @@ public final class Setting<Value: SettingValue> {
     self.write = write
     self.value = read(store, key) ?? defaultValue
     self.observer = SettingObserver()
-    // All stored properties are now initialized; safe to capture
-    // `self` and register with the store.
-    self.observer.onChange = { [weak self] in
+    installObserver()
+  }
+
+  /// Wire the KVO bridge. Called from every designated init once all
+  /// stored properties are initialized, so it's safe to capture `self`
+  /// and register with the store.
+  private func installObserver() {
+    observer.onChange = { [weak self] in
       // KVO fires on whatever thread performed the write (or a
       // background queue for cross-process `userdefaultsd`
       // callbacks), so we always hop to the main actor.
+      //
+      // `DispatchQueue.main.async` (not `Task { @MainActor in … }`) is
+      // load-bearing: the test suite drains the main queue with a
+      // FIFO sentinel, which relies on dispatch ordering that Tasks
+      // do not guarantee. Don't "modernize" this without also
+      // replacing the test drain.
       DispatchQueue.main.async {
         MainActor.assumeIsolated {
           self?._applyExternalChange()
         }
       }
     }
-    // Do NOT pass `.initial` — `init` already seeded `value` by
-    // reading the store directly above.
-    store.addObserver(self.observer, forKeyPath: key, options: [.new], context: nil)
+    // Do NOT pass `.initial` — each init already seeded `value` by
+    // reading the store directly.
+    store.addObserver(observer, forKeyPath: key, options: [.new], context: nil)
   }
 
   nonisolated deinit {

--- a/Sources/Splint/Setting.swift
+++ b/Sources/Splint/Setting.swift
@@ -6,17 +6,38 @@ import Observation
 /// Prefer many small `Setting` instances over a single "settings object":
 /// each `Setting` is its own observation point, so views reading one
 /// setting do not re-evaluate when an unrelated setting changes.
+///
+/// Multiple `Setting` instances bound to the same key stay in sync
+/// automatically via `UserDefaults` key-value observation. A write to
+/// one instance — or a direct `UserDefaults.set(_:forKey:)` from
+/// anywhere — propagates to every other `Setting` on that key. When the
+/// store is an App Group suite (`UserDefaults(suiteName: "group.…")`),
+/// the same mechanism keeps Settings in sync between the host app and
+/// its extensions via `userdefaultsd`.
 @Observable
 @MainActor
 public final class Setting<Value: SettingValue> {
   /// The current value. Writes persist to the underlying store.
   public var value: Value {
-    didSet { persist() }
+    didSet {
+      // Skip persisting when we're applying an externally-observed
+      // change — otherwise we'd write back the same value we just
+      // observed and bounce KVO indefinitely.
+      guard !isApplyingExternalChange else { return }
+      persist()
+    }
   }
 
+  @ObservationIgnored private var isApplyingExternalChange = false
   @ObservationIgnored private let key: String
   @ObservationIgnored private let defaultValue: Value
-  @ObservationIgnored private let store: UserDefaults
+  // `store` and `observer` must be reachable from `deinit`, which runs
+  // nonisolated on `@MainActor` classes in Swift 6. Both are
+  // thread-safe to touch from `deinit`: `UserDefaults.removeObserver`
+  // is documented as thread-safe, and `observer` is never mutated
+  // after `init` returns.
+  @ObservationIgnored private nonisolated(unsafe) let store: UserDefaults
+  @ObservationIgnored private let observer: SettingObserver
   @ObservationIgnored private let read: (UserDefaults, String) -> Value?
   @ObservationIgnored private let write: (UserDefaults, String, Value) -> Void
 
@@ -33,6 +54,22 @@ public final class Setting<Value: SettingValue> {
     self.read = read
     self.write = write
     self.value = read(store, key) ?? defaultValue
+    self.observer = SettingObserver()
+    // All stored properties are now initialized; safe to capture
+    // `self` and register with the store.
+    self.observer.onChange = { [weak self] in
+      // KVO fires on whatever thread performed the write (or a
+      // background queue for cross-process `userdefaultsd`
+      // callbacks), so we always hop to the main actor.
+      DispatchQueue.main.async {
+        MainActor.assumeIsolated {
+          self?._applyExternalChange()
+        }
+      }
+    }
+    // Do NOT pass `.initial` — `init` already seeded `value` by
+    // reading the store directly above.
+    store.addObserver(self.observer, forKeyPath: key, options: [.new], context: nil)
   }
 
   /// Internal designated init used by the `RawRepresentable` extension.
@@ -50,12 +87,67 @@ public final class Setting<Value: SettingValue> {
     self.read = read
     self.write = write
     self.value = read(store, key) ?? defaultValue
+    self.observer = SettingObserver()
+    // All stored properties are now initialized; safe to capture
+    // `self` and register with the store.
+    self.observer.onChange = { [weak self] in
+      // KVO fires on whatever thread performed the write (or a
+      // background queue for cross-process `userdefaultsd`
+      // callbacks), so we always hop to the main actor.
+      DispatchQueue.main.async {
+        MainActor.assumeIsolated {
+          self?._applyExternalChange()
+        }
+      }
+    }
+    // Do NOT pass `.initial` — `init` already seeded `value` by
+    // reading the store directly above.
+    store.addObserver(self.observer, forKeyPath: key, options: [.new], context: nil)
+  }
+
+  nonisolated deinit {
+    store.removeObserver(observer, forKeyPath: key)
   }
 
   /// Restore the default value and remove the underlying key from the store.
   public func reset() {
     value = defaultValue
     store.removeObject(forKey: key)
+  }
+
+  /// Apply an externally-observed change to `value`. The KVO callback
+  /// funnels through here; exposed via `@_spi(Internal)` so the
+  /// equality guard can be unit-tested without depending on
+  /// `userdefaultsd` timing.
+  ///
+  /// Disambiguates two distinct nil-from-`read` cases:
+  /// - Key truly absent → reset to `defaultValue` (this is how
+  ///   ``reset()`` propagates to other Setting instances).
+  /// - Key present with an undecodable value (wrong type, or for
+  ///   `RawRepresentable`, an unknown raw case) → ignore. Refusing to
+  ///   touch `value` here is what prevents an external garbage write
+  ///   from silently clobbering a valid user preference.
+  @_spi(Internal)
+  public func _applyExternalChange() {
+    let new: Value
+    if store.object(forKey: key) == nil {
+      // Key removed (or never set) — fall back to the default so
+      // observers see resets propagated from other instances.
+      new = defaultValue
+    } else if let decoded = read(store, key) {
+      new = decoded
+    } else {
+      // Key has a value but it's not decodable as `Value` (wrong
+      // type, or unknown enum case). Leave `value` untouched.
+      return
+    }
+    // `Value: Equatable` via `SettingValue`. Skipping when unchanged
+    // prevents redundant assignments (and the didSet work that would
+    // follow) from double-fired KVO callbacks.
+    guard new != value else { return }
+    isApplyingExternalChange = true
+    value = new
+    isApplyingExternalChange = false
   }
 
   private func persist() {
@@ -86,5 +178,22 @@ extension Setting where Value: RawRepresentable, Value.RawValue: SettingValue {
         s.set(v.rawValue, forKey: k)
       }
     )
+  }
+}
+
+/// KVO→closure bridge. Exists only to let `Setting` observe a single
+/// UserDefaults key; the `@unchecked Sendable` is safe because
+/// `onChange` is only written during `Setting.init` (before the
+/// observer is registered) and read from the KVO callback.
+private final class SettingObserver: NSObject, @unchecked Sendable {
+  var onChange: (() -> Void)?
+
+  override func observeValue(
+    forKeyPath keyPath: String?,
+    of object: Any?,
+    change: [NSKeyValueChangeKey: Any]?,
+    context: UnsafeMutableRawPointer?
+  ) {
+    onChange?()
   }
 }

--- a/Sources/Splint/SettingValue.swift
+++ b/Sources/Splint/SettingValue.swift
@@ -9,7 +9,11 @@ import Foundation
 /// `Codable` structs are also absent — encoding arbitrary structs into
 /// `Data` and stashing them in `UserDefaults` is an antipattern. Use
 /// SwiftData for structured persistence.
-public protocol SettingValue: Sendable {}
+///
+/// `Equatable` is required so that ``Setting`` can suppress redundant
+/// observation cycles when an external KVO callback delivers a value
+/// that matches the current one.
+public protocol SettingValue: Sendable & Equatable {}
 
 extension Bool: SettingValue {}
 extension Int: SettingValue {}

--- a/Tests/SplintTests/SettingTests.swift
+++ b/Tests/SplintTests/SettingTests.swift
@@ -1,7 +1,41 @@
 import Foundation
 import Testing
 
-@testable import Splint
+@_spi(Internal) @testable import Splint
+
+/// Drain one main-queue turn. The `Setting` KVO callback hops to main
+/// via `DispatchQueue.main.async`; this sentinel lands after it (FIFO),
+/// guaranteeing the callback has run when the continuation resumes. No
+/// hard sleep — purely event-driven.
+@MainActor
+private func drainMain() async {
+  await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+    DispatchQueue.main.async { c.resume() }
+  }
+}
+
+/// `UserDefaults` is documented thread-safe but isn't marked
+/// `Sendable`. Wrap to make off-main captures explicit for Swift 6
+/// strict concurrency.
+private struct SendableStore: @unchecked Sendable {
+  let store: UserDefaults
+  init(_ store: UserDefaults) { self.store = store }
+}
+
+/// `UserDefaults` subclass that counts `set(_:forKey:)` invocations.
+/// Used by `selfWriteDoesNotLoop` to catch regressions of the
+/// re-entry guard — a regression would show up as `setCount > 1` for
+/// a single local write, instead of hanging the runner.
+private final class CountingUserDefaults: UserDefaults, @unchecked Sendable {
+  private let lock = NSLock()
+  private var _setCount = 0
+  var setCount: Int { lock.withLock { _setCount } }
+
+  override func set(_ value: Any?, forKey defaultName: String) {
+    lock.withLock { _setCount += 1 }
+    super.set(value, forKey: defaultName)
+  }
+}
 
 @MainActor
 @Suite("Setting")
@@ -9,6 +43,13 @@ struct SettingTests {
   private func freshStore(_ fn: String = #function) -> UserDefaults {
     let suite = "SplintTests.Setting.\(fn).\(UUID().uuidString)"
     let store = UserDefaults(suiteName: suite)!
+    store.removePersistentDomain(forName: suite)
+    return store
+  }
+
+  private func freshCountingStore(_ fn: String = #function) -> CountingUserDefaults {
+    let suite = "SplintTests.Setting.\(fn).\(UUID().uuidString)"
+    let store = CountingUserDefaults(suiteName: suite)!
     store.removePersistentDomain(forName: suite)
     return store
   }
@@ -64,5 +105,237 @@ struct SettingTests {
     s.reset()
     #expect(s.value == .light)
     #expect(store.object(forKey: "theme") == nil)
+  }
+
+  // MARK: - Issue #5: multi-instance synchronization
+
+  /// Issue footgun #1. Outer integration test: two `Setting` instances
+  /// bound to the same key/store must stay in sync via UserDefaults
+  /// KVO. Writes through either instance — or directly to the
+  /// underlying store — propagate to all observers.
+  @Test func multipleInstancesStaySynchronized() async {
+    let store = freshStore()
+    let a = Setting<Bool>("flag", default: false, store: store)
+    let b = Setting<Bool>("flag", default: false, store: store)
+
+    a.value = true
+    await drainMain()
+    #expect(b.value == true, "B should observe A's write")
+
+    b.value = false
+    await drainMain()
+    #expect(a.value == false, "A should observe B's write")
+
+    store.set(true, forKey: "flag")
+    await drainMain()
+    #expect(a.value == true, "A should observe direct store write")
+    #expect(b.value == true, "B should observe direct store write")
+  }
+
+  /// Issue footgun #2. A single self-write must produce exactly one
+  /// underlying `store.set` call. Without the `isApplyingExternalChange`
+  /// re-entry guard, the KVO callback would set `value` again, fire
+  /// `didSet`, persist again — an infinite feedback loop. Relies on
+  /// `[weak self]` self-termination (the local Setting deallocates at
+  /// end of scope, breaking any in-flight chain) rather than a
+  /// `.timeLimit` trait.
+  @Test func selfWriteDoesNotLoop() async {
+    let store = freshCountingStore()
+    let s = Setting<Bool>("flag", default: false, store: store)
+    s.value = true
+    await drainMain()
+    #expect(store.setCount == 1, "self-write must hit the store exactly once")
+    #expect(s.value == true, "self-write must take effect locally")
+  }
+
+  /// Issue footgun #3. The equality guard inside `_applyExternalChange()`
+  /// must skip redundant assignments when the underlying store value
+  /// already matches `value`. Tested directly through the SPI rather
+  /// than depending on `userdefaultsd` daemon timing.
+  @Test func equalityGuardSkipsRedundantApplications() async {
+    let store = freshCountingStore()
+    let s = Setting<Bool>("flag", default: false, store: store)
+    s.value = true
+    await drainMain()
+    let baselineWrites = store.setCount
+
+    // Drive the external-change path repeatedly with no change to the
+    // underlying value; the guard should make every call a no-op.
+    s._applyExternalChange()
+    s._applyExternalChange()
+    s._applyExternalChange()
+
+    #expect(s.value == true, "value must stay put")
+    #expect(store.setCount == baselineWrites, "no additional persist calls")
+  }
+
+  /// Issue footgun #4. A direct `UserDefaults.set` write — bypassing
+  /// every `Setting` instance — must still propagate to the Setting
+  /// via KVO.
+  @Test func externalStoreWriteReflectsInSetting() async {
+    let store = freshStore()
+    let s = Setting<Bool>("flag", default: true, store: store)
+    store.set(false, forKey: "flag")
+    await drainMain()
+    #expect(s.value == false)
+  }
+
+  // (Issue footgun #5, App Group cross-process sync, deliberately not
+  // automated. SPM tests can't acquire an App Group entitlement
+  // without restructuring to xcodebuild + a host app target. Cross-
+  // process sync is documented in README as the OS guarantee that
+  // standard KVO on a shared suite leverages.)
+
+  /// Issue footgun #6. Dropping the last strong reference to a
+  /// `Setting` must trigger `deinit`, which removes the KVO observer
+  /// from the store. After release, writes to the store must not
+  /// crash even though our observer is gone.
+  @Test func deinitRemovesObserver() async {
+    let store = freshStore()
+    weak var weakSetting: Setting<Bool>?
+    do {
+      let s = Setting<Bool>("flag", default: false, store: store)
+      weakSetting = s
+      s.value = true
+    }
+    // Allow any in-flight KVO-dispatched blocks to clear.
+    await drainMain()
+    #expect(weakSetting == nil, "Setting must deallocate when last strong ref drops")
+
+    // If `removeObserver` regressed, this write would call into freed
+    // memory and crash. The assertion is implicit (no crash).
+    store.set(false, forKey: "flag")
+    await drainMain()
+  }
+
+  /// Issue footgun #7. Many `Setting` instances created and dropped in
+  /// a tight loop must all deallocate. Catches regressions where a
+  /// retain cycle (e.g., the observer closure capturing `self`
+  /// strongly) prevents `deinit`.
+  @Test func manySettingsDeinitCleanly() async {
+    let store = freshStore()
+    var weakProbes: [() -> Bool] = []
+    do {
+      var settings: [Setting<Int>] = []
+      for i in 0..<100 {
+        let s = Setting<Int>("k_\(i)", default: 0, store: store)
+        // `[weak s]` makes the probe non-retaining; the closure
+        // returns true once the underlying instance is gone.
+        weakProbes.append { [weak s] in s == nil }
+        settings.append(s)
+      }
+      _ = settings
+    }
+    await drainMain()
+    let leaked = weakProbes.filter { !$0() }.count
+    #expect(leaked == 0, "expected all 100 Settings to deallocate, \(leaked) leaked")
+  }
+
+  /// Issue footgun #8. The `RawRepresentable` init path must wire up
+  /// KVO identically to the standard init. Two enum-typed Settings on
+  /// the same key must stay in sync, and a raw-string write to the
+  /// store must propagate as well.
+  @Test func rawRepresentableEnumsSyncCorrectly() async {
+    let store = freshStore()
+    let a = Setting<Theme>("theme", default: .light, store: store)
+    let b = Setting<Theme>("theme", default: .light, store: store)
+
+    a.value = .dark
+    await drainMain()
+    #expect(b.value == .dark, "B should observe A's enum write")
+
+    store.set("light", forKey: "theme")
+    await drainMain()
+    #expect(a.value == .light, "A should observe direct raw-string write")
+    #expect(b.value == .light, "B should observe direct raw-string write")
+  }
+
+  /// Issue footgun #9. An external write of a wrong-typed value must
+  /// be silently ignored — `value` must not be touched. Critically,
+  /// `value` must NOT silently revert to `defaultValue` either; this
+  /// regression test seeds `value` to something different from
+  /// `defaultValue` first so the wrong-typed write would actually
+  /// flip it if the implementation conflated "undecodable" with "key
+  /// absent".
+  @Test func typeMismatchedExternalWriteIsIgnored() async {
+    let store = freshStore()
+    let s = Setting<Bool>("flag", default: false, store: store)
+    // Move `value` to the non-default position via a legitimate write.
+    store.set(true, forKey: "flag")
+    await drainMain()
+    #expect(s.value == true, "precondition: legitimate write took effect")
+
+    // Now smuggle in a wrong-typed value. The only correct response
+    // is "leave `value` alone" — falling back to `defaultValue`
+    // (false) here would silently destroy the user's preference.
+    store.set("not a bool", forKey: "flag")
+    await drainMain()
+
+    #expect(s.value == true, "undecodable external write must not clobber value")
+  }
+
+  /// Issue footgun #9 (reset-propagation companion). After a key
+  /// removal — distinct from a wrong-typed write — `value` must fall
+  /// back to `defaultValue`. This is the same nil-from-`read` shape
+  /// that the wrong-type case produces, so the implementation must
+  /// disambiguate by checking key presence in the store.
+  @Test func keyRemovalExternallyResetsToDefault() async {
+    let store = freshStore()
+    let s = Setting<Bool>("flag", default: false, store: store)
+    store.set(true, forKey: "flag")
+    await drainMain()
+    #expect(s.value == true, "precondition: legitimate write took effect")
+
+    store.removeObject(forKey: "flag")
+    await drainMain()
+
+    #expect(s.value == false, "external key removal must reset to default")
+  }
+
+  /// Issue footgun #10. A write made from a background `Task.detached`
+  /// must propagate to the main-actor Setting without crashes or data
+  /// races. Verifies the `DispatchQueue.main.async` + `assumeIsolated`
+  /// bridge handles off-main KVO callbacks.
+  @Test func concurrentBackgroundWriteUpdatesOnMain() async {
+    let store = freshStore()
+    let s = Setting<Bool>("flag", default: false, store: store)
+
+    // `UserDefaults` isn't `Sendable`, but its setters are documented
+    // as thread-safe. Wrap to make the cross-actor capture explicit
+    // for Swift 6 strict concurrency.
+    let sendable = SendableStore(store)
+    await Task.detached {
+      sendable.store.set(true, forKey: "flag")
+    }.value
+
+    await drainMain()
+    #expect(s.value == true)
+  }
+
+  /// Issue footgun #11. With KVO wired in, the default-when-key-absent
+  /// path must still produce the default. (Re-asserted alongside the
+  /// pre-existing `readsDefaultWhenKeyAbsent` test.)
+  @Test func defaultWhenKeyAbsentAfterKVOInit() {
+    let store = freshStore()
+    let s = Setting<Int>("missing", default: 7, store: store)
+    #expect(s.value == 7)
+  }
+
+  /// Issue footgun #12. `reset()` removes the key from the store,
+  /// which must propagate to other Setting instances on the same
+  /// key — they should fall back to their default.
+  @Test func resetClearsKeyAndNotifiesOtherInstances() async {
+    let store = freshStore()
+    let a = Setting<Theme>("theme", default: .light, store: store)
+    let b = Setting<Theme>("theme", default: .light, store: store)
+
+    a.value = .dark
+    await drainMain()
+    #expect(b.value == .dark)
+
+    b.reset()
+    await drainMain()
+    #expect(b.value == .light, "B reset locally")
+    #expect(a.value == .light, "A should observe B's reset (key removed)")
   }
 }


### PR DESCRIPTION
Closes #5.

## Summary

- `Setting` now observes its key via `UserDefaults` KVO, so multiple instances on the same key/store stay in sync — and App Group suites stay in sync across the host app and its extensions via `userdefaultsd`.
- A re-entry flag (`isApplyingExternalChange`) prevents the `didSet → store.set → KVO → didSet` feedback loop, and an equality guard suppresses redundant assignments from double-fired KVO callbacks.
- `SettingValue` now requires `Equatable` (in addition to `Sendable`). Every built-in conformer is already `Equatable`; user-defined conformers must add it.

## Notable design choices

- **KVO callback always hops to main via `DispatchQueue.main.async`.** The bare `MainActor.assumeIsolated` from the issue sketch would crash on off-main writes (e.g., `Task.detached`) and on cross-process callbacks from `userdefaultsd`. Async dispatch is FIFO and never crashes.
- **`_applyExternalChange()` disambiguates two distinct nil-from-`read` cases.** Key truly absent → fall back to `defaultValue` (so `reset()` propagates to other instances). Key present with an undecodable value → ignore (so a wrong-typed external write can't silently clobber a valid user preference). Works uniformly for the standard and `RawRepresentable` paths.
- **`nonisolated deinit` removes the observer.** `store` is `nonisolated(unsafe) let` because Swift 6 `@MainActor` deinits run nonisolated; `UserDefaults.removeObserver` is documented thread-safe.
- **No `.timeLimit` traits anywhere.** Swift Testing only allows minute granularity (verified against the [TimeLimitTrait source](https://github.com/swiftlang/swift-testing/blob/main/Sources/Testing/Traits/TimeLimitTrait.swift)). The self-write loop test relies instead on a `CountingUserDefaults` write counter and `[weak self]` self-termination — a stronger signal than any timeout would give.
- **No hard sleeps in tests.** A `drainMain()` sentinel-drain (one `DispatchQueue.main.async` round-trip) bridges the asynchronous KVO callback deterministically.
- **Test #5 (App Group cross-process sync) deliberately omitted.** SPM tests can't acquire App Group entitlements without restructuring to xcodebuild + a host app target. Cross-process sync is documented in README as the OS guarantee that standard KVO leverages.

## Test plan

- [x] `script/test` — all 72 tests pass across 7 suites
- [x] `swift format lint --strict` clean for all changed files
- [x] 11 footgun scenarios from the issue are covered (test #5 intentionally skipped, see above), plus a new `keyRemovalExternallyResetsToDefault` regression test for the disambiguation
- [x] `selfWriteDoesNotLoop` uses a write-counting UserDefaults subclass to assert exactly one persist call per local write
- [x] `equalityGuardSkipsRedundantApplications` exercises the equality guard directly via the SPI
- [x] `typeMismatchedExternalWriteIsIgnored` seeds `value` to differ from `defaultValue` first, so the assertion would fail if the implementation conflated "undecodable" with "key absent"
- [x] `manySettingsDeinitCleanly` and `deinitRemovesObserver` confirm no retain cycle and no leaked observers
- [x] `concurrentBackgroundWriteUpdatesOnMain` verifies off-main writes bridge cleanly to the main actor

🤖 Generated with [Claude Code](https://claude.com/claude-code)