### PR TITLE
Fix flaky loadWhileRunningCancelsPrevious (#12)

### DIFF
--- a/Sources/Splint/Catalog.swift
+++ b/Sources/Splint/Catalog.swift
@@ -35,6 +35,13 @@ public final class Catalog<Item: Resource, Criteria: Equatable & Sendable> {
 
   @ObservationIgnored private let fetch: @Sendable (Criteria) async throws -> [Item]
   @ObservationIgnored private var task: Task<Void, Never>?
+  @ObservationIgnored private var fetchGeneration: UInt64 = 0
+
+  /// Underlying task for the most recent fetch. Exposed to tests so
+  /// they can synchronize deterministically on fetch completion instead
+  /// of polling ``phase``.
+  @_spi(Internal)
+  public var currentTask: Task<Void, Never>? { task }
 
   public init(fetch: @escaping @Sendable (Criteria) async throws -> [Item]) {
     self.fetch = fetch
@@ -73,17 +80,19 @@ public final class Catalog<Item: Resource, Criteria: Equatable & Sendable> {
 
   private func performFetch(_ criteria: Criteria) {
     task?.cancel()
+    fetchGeneration &+= 1
+    let myGeneration = fetchGeneration
     phase = .running
     task = Task { [weak self, fetch] in
       do {
         let fetched = try await fetch(criteria)
-        guard !Task.isCancelled else { return }
-        self?.items = fetched
-        self?.lastLoaded = .now
-        self?.phase = .completed
+        guard let self, self.fetchGeneration == myGeneration else { return }
+        self.items = fetched
+        self.lastLoaded = .now
+        self.phase = .completed
       } catch {
-        guard !Task.isCancelled else { return }
-        self?.phase = .failed(error.localizedDescription)
+        guard let self, self.fetchGeneration == myGeneration else { return }
+        self.phase = .failed(error.localizedDescription)
       }
     }
   }

--- a/Tests/SplintTests/CatalogTests.swift
+++ b/Tests/SplintTests/CatalogTests.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Testing
 
-@testable import Splint
+@_spi(Internal) @testable import Splint
 
 struct TestItem: Resource {
   let id: Int
@@ -180,12 +180,13 @@ struct CatalogTests {
     }
     c.load(TestCriteria(category: "1"))
     await waitUntil { c.phase == .running }
+    let task1 = c.currentTask
     c.load(TestCriteria(category: "2"))
-    await waitUntil { c.phase == .completed }
+    await c.currentTask?.value
     #expect(c.items.first?.name == "2")
-    // Let the first (cancelled) task wake up — it must NOT overwrite items.
+    // Let the first (superseded) task wake up — it must NOT overwrite items.
     await gate.open()
-    try? await Task.sleep(for: .milliseconds(50))
+    await task1?.value
     #expect(c.items.first?.name == "2")
   }
 


### PR DESCRIPTION
Closes #12.

## Summary

`CatalogTests.loadWhileRunningCancelsPrevious` failed under full-suite contention with two symptoms in a single run:

1. `items.first?.name` was `nil` — the 2-second `waitUntil { c.phase == .completed }` poll timed out because Task2's MainActor hop was starved.
2. `items.first?.name` was `"stale"` — after `gate.open()`, the cancelled Task1 still wrote its result despite the `guard !Task.isCancelled else { return }` guard.

Two changes address both:

- **Harden `Catalog`**: replace the `Task.isCancelled` guard with a `fetchGeneration: UInt64` counter. `performFetch` bumps the counter before spawning the task; each task captures its generation and checks `self.fetchGeneration == myGeneration` before writing. Any newer `performFetch` advances the counter, so a superseded task physically cannot overwrite newer results — independent of Swift's cooperative-cancellation semantics. `guard let self` still handles deinit.
- **Deterministic test**: expose `currentTask` via `@_spi(Internal)` (matching CLAUDE.md's documented SPI label) and replace both timing-based sync points — `await c.currentTask?.value` in place of the 2s `waitUntil`, and `await task1?.value` in place of the 50ms sleep. The test no longer has any timing-based synchronization on the flaky paths.

## Test plan

- [x] `script/test_fast` — passes
- [x] `script/test` (full suite + 100% coverage gate on `Sources/Splint/`) — 74 tests, 100% coverage
- [x] 20× isolated stress: `for i in $(seq 1 20); do swift test --filter loadWhileRunningCancelsPrevious; done` — 20/20
- [x] 20× full-suite stress (the original flake condition): 20/20

🤖 Generated with [Claude Code](https://claude.com/claude-code)