### PR TITLE
Prove Job.run forwards priority to underlying Task

### DIFF
--- a/Tests/SplintTests/JobTests.swift
+++ b/Tests/SplintTests/JobTests.swift
@@ -143,6 +143,18 @@ struct JobTests {
     #expect(job.phase == .failed("later"))
   }
 
+  /// Proves the `priority:` argument is forwarded to the underlying
+  /// `Task(priority:)`. `.background` is used because it sits far below
+  /// the `@MainActor` context's inherited QoS — observing it inside the
+  /// task can only happen if the parameter actually reached
+  /// `Task(priority:)`.
+  @Test func runForwardsPriorityToUnderlyingTask() async {
+    let job = Job<TaskPriority>()
+    job.run(priority: .background) { Task.currentPriority }
+    await waitUntil { job.phase == .completed }
+    #expect(job.value == .background)
+  }
+
   /// Compile-guard for SE-0430: the `task:` parameter is `sending`, not
   /// `@Sendable`. A non-`Sendable` reference captured into the closure
   /// must compile here. The `#expect` is incidental — the load-bearing


### PR DESCRIPTION
## Summary

- `Job.run(priority:)` accepted a `TaskPriority?` but no test varied it from `nil`, so a bug that silently dropped the argument wouldn't fail any test.
- Adds a single `@Test` that captures `Task.currentPriority` *inside* the closure and asserts it equals the `.background` value passed in — end-to-end proof the parameter travels through to `Task(priority:)`.

## Why `.background`

`@MainActor` context inherits a non-`.low` default QoS. Passing `.high` would've been ambiguous — the assertion could've passed even with the parameter discarded. `.background` sits far below anything the MainActor would inherit, so observing it can only happen if the argument was honored.

## Mutation check

Replacing `Task(priority: priority)` with `Task(priority: nil)` in [Sources/Splint/Job.swift:45](https://github.com/searlsco/splint/blob/main/Sources/Splint/Job.swift#L45) flips the observed value to `.medium` and the new test fails. Reverted after verification.

## Test plan

- [x] `./script/test_fast` — 65 tests pass
- [x] `./script/test` — 75 tests pass, coverage stays at 100%
- [x] Mutation: break production code → test fails; restore → test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)