### PR TITLE
Fix claude-review workflow to post PR comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -38,7 +38,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           show_full_output: true
           display_report: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## Summary

The `Claude Code Review` workflow runs successfully on every PR but never posts its findings back to the PR. Two bugs combine to cause this:

1. The `prompt:` passes `/code-review:code-review` **without the `--comment` flag**. Per the plugin docs (and the reviewer's own terminal output on [run 24564360511](https://github.com/searlsco/splint/actions/runs/24564360511/job/71820597354?pr=17): *"`--comment` was not provided, so no GitHub comment was posted"*), `--comment` is what makes it post to GitHub.
2. The job's `permissions:` block grants `pull-requests: read`. Posting review comments requires `pull-requests: write`, so even with the flag added, the write would be rejected.

This PR fixes both in [.github/workflows/claude-code-review.yml](https://github.com/searlsco/splint/blob/fix/claude-review-comment-flag/.github/workflows/claude-code-review.yml):

- `pull-requests: read` → `pull-requests: write`
- Add `--comment` to the prompt

## Test plan

- [ ] This PR itself exercises the workflow — confirm the claude-review bot leaves a comment on it (or on a follow-up PR if this one is too trivial to flag).
- [ ] Optional: open a follow-up PR that deliberately violates a CLAUDE.md rule (e.g. add a `script/foo` stub without updating the `script/` suite table) and confirm the bot comments with the finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)