### PR TITLE
Adopt typed throws on Credential read/save/delete (#19)

### DIFF
--- a/Sources/Splint/Credential.swift
+++ b/Sources/Splint/Credential.swift
@@ -52,7 +52,10 @@ public struct Credential: Sendable {
   }
 
   /// Read the current value, or `nil` if absent.
-  public func read() throws -> String? {
+  ///
+  /// - Throws: ``KeychainError`` when `SecItemCopyMatching` returns a
+  ///   non-success, non-"not found" status.
+  public func read() throws(KeychainError) -> String? {
     let (status, data) = backend.read(
       service: service, account: account, synchronizable: synchronizable)
     switch status {
@@ -69,7 +72,10 @@ public struct Credential: Sendable {
   /// Save the value. Creates the item if absent, updates it in place if
   /// present. Does NOT delete-then-add (which would churn the item's
   /// creation date and can cause iCloud Keychain sync conflicts).
-  public func save(_ value: String) throws {
+  ///
+  /// - Throws: ``KeychainError`` when either the add or the fallback
+  ///   update returns a non-success status.
+  public func save(_ value: String) throws(KeychainError) {
     let data = Data(value.utf8)
     let addStatus = backend.add(
       service: service, account: account, synchronizable: synchronizable, data: data)
@@ -88,7 +94,10 @@ public struct Credential: Sendable {
   }
 
   /// Delete the credential. Missing items are not an error.
-  public func delete() throws {
+  ///
+  /// - Throws: ``KeychainError`` when `SecItemDelete` returns a
+  ///   non-success, non-"not found" status.
+  public func delete() throws(KeychainError) {
     let status = backend.delete(
       service: service, account: account, synchronizable: synchronizable)
     switch status {


### PR DESCRIPTION
## Summary

- Narrow `Credential.read()`, `save(_:)`, and `delete()` from untyped `throws` to `throws(KeychainError)`. Bodies only ever threw `KeychainError` already, so this is a signature refinement with no behavior change.
- Add `- Throws: ``KeychainError``…` DocC lines to each method so the rendered docs reflect the typed-throws contract.

Closes #19.

## Why

Consumers get exhaustive `catch` on keychain failures without an `as? KeychainError` cast. Zero ABI risk at 0.x and matches the project's latest-toolchain-only posture (Swift 6.1+ typed throws).

## Test plan

- [x] `./script/test` — full suite passes, 100% coverage on `Sources/Splint/` preserved.
- [x] Existing `CredentialTests` already exercise every throw branch via injected backend stubs; no test changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)