### PR TITLE
Add per-type DocC articles for each Splint primitive

### DIFF
--- a/Sources/Splint/Splint.docc/CatalogGuide.md
+++ b/Sources/Splint/Splint.docc/CatalogGuide.md
@@ -1,0 +1,130 @@
+# Catalogs of remote resources
+
+An observable, ordered collection of ``Resource`` values fetched by
+criteria, plus the fetch lifecycle.
+
+## Overview
+
+Almost every real catalog is parameterized — channels need a provider,
+programs need a channel, EPG entries need a channel and a date range. A
+``Catalog`` bundles the collection, the criteria that produced it, and
+the fetch lifecycle into a single `@Observable` whose fields are
+observed independently.
+
+The parameter-free case is handled by a convenience on ``NoCriteria``:
+call `catalog.load()` with no argument.
+
+## Usage
+
+```swift
+struct BookCriteria: Equatable, Sendable {
+    let libraryID: String
+}
+
+let catalog = Catalog<Book, BookCriteria> { criteria in
+    try await api.fetchBooks(in: criteria.libraryID)
+}
+
+catalog.load(BookCriteria(libraryID: "main"))
+```
+
+Pair with SwiftUI:
+
+```swift
+.task(id: channel.id) {
+    catalog.load(ProgramCriteria(channelID: channel.id))
+}
+```
+
+SwiftUI cancels and relaunches the task when the id changes — free
+cancellation of the old fetch.
+
+## `load(_:)` vs `refresh()`
+
+The most important API distinction in Splint:
+
+- `catalog.load(newCriteria)` — criteria changed; old items are *wrong*
+  (channel A's programs when you asked for channel B). Clears items
+  immediately so the view shows loading, not wrong data.
+- `catalog.refresh()` — same criteria; items stay visible during fetch.
+  This is pull-to-refresh, periodic polling, "show stale and update in
+  place." No-op if `load()` has never been called.
+- `catalog.retry()` — alias for `refresh()`; reads better after
+  failure.
+
+## Catalog lifecycle
+
+Scope the catalog to the narrowest view that fully contains its usage.
+Every catalog is `@State` on the owning view, distributed via
+`.environment()`. The catalog lives exactly as long as that view.
+
+- **Session-scoped** (channels for the logged-in provider): `@State` on
+  the authenticated root view — *not* the app root. Logout destroys
+  that root, deallocates the catalog, and cancels in-flight fetches via
+  `deinit`. Logging into a different provider creates a fresh catalog
+  with no stale data.
+- **Navigation-scoped** (programs for a specific channel): `@State` on
+  the detail view. Created on push, destroyed on pop.
+- **Persistent-detail** (iPad sidebar/detail, macOS split view):
+  `@State` on the detail view that survives selection changes. Driven
+  by `.task(id: selectedItem.id) { catalog.load(newCriteria) }`. The
+  instance persists across selections — this is where the
+  criteria-clearing branch in `load()` earns its keep, preventing
+  channel A's programs from showing while channel B's load.
+
+The catalog doesn't decide its own lifecycle — SwiftUI does, based on
+where you store the instance.
+
+## Dependency injection happens at init
+
+The fetch closure captures its dependencies at construction time. DI
+happens before the Catalog exists, not after:
+
+```swift
+init(client: BookClient) {
+    self._catalog = State(initialValue: Catalog(fetch: client.fetchBooks))
+}
+```
+
+No singletons, no late-binding, no service locators. The same rule
+applies to ``Lens`` filter/sort closures.
+
+## Narrowly-scoped catalogs over client-side filtering
+
+Large datasets should be scoped via criteria, not fetched in bulk and
+filtered client-side with ``Lens``:
+
+```swift
+struct ProgramGuideView: View {
+    let channel: Channel
+    @State private var programs: Catalog<Program, ScheduleCriteria>
+
+    init(channel: Channel, api: IPTVClient) {
+        self.channel = channel
+        self._programs = State(initialValue: Catalog { criteria in
+            try await api.fetchPrograms(for: criteria.channelID, on: criteria.date)
+        })
+    }
+
+    var body: some View {
+        ProgramList(programs: programs)
+            .task {
+                programs.load(ScheduleCriteria(channelID: channel.id, date: .now))
+            }
+    }
+}
+```
+
+The API returns programs for one channel on one date. The catalog
+holds hundreds, not thousands. If you need filtering within that
+result (e.g. by genre), ``Lens`` is appropriate at this scale.
+
+## Topics
+
+### Related
+
+- ``Resource``
+- ``Lens``
+- ``Phase``
+- ``NoCriteria``
+- <doc:ObservationBoundaries>

--- a/Sources/Splint/Splint.docc/ChoosingTheRightType.md
+++ b/Sources/Splint/Splint.docc/ChoosingTheRightType.md
@@ -1,0 +1,69 @@
+# Choosing the right type
+
+A decision guide for picking a Splint primitive — or deliberately not
+picking one.
+
+## Overview
+
+Every SwiftUI app assembles views from the same handful of data shapes.
+Splint names them. The library is *corrective, not prescriptive*: it
+does not replace SwiftUI's architecture, it names the things you put
+into `@State`, `@Environment`, `@Query`, and `@Observable`.
+
+## The type inventory
+
+| Type | What it holds | Observation | Persistence | Mutability |
+|------|---------------|-------------|-------------|------------|
+| ``Resource`` | Decoded remote data | None — value type | None | Immutable after decode |
+| ``Catalog`` | Ordered collection of Resources loaded by criteria, plus fetch lifecycle | `@Observable` | None (in-memory cache) | Collection mutates on load/refresh |
+| ``Lens`` | Filtered/sorted/grouped view over a ``Catalog`` | `@Observable` | None | Criteria mutate; data is derived |
+| ``Job`` | Async operation lifecycle | `@Observable` | None | Phase mutates as work progresses |
+| ``Selection`` | Currently selected item identifier | `@Observable` | None | Mutates on user tap |
+| ``Setting`` | Single typed user preference | `@Observable` | UserDefaults | Mutates, persists automatically |
+| ``Credential`` | Keychain-backed secret | None — read on demand | Keychain | Mutates via explicit save/delete |
+
+## Decision guide
+
+- Decoded remote data → ``Resource``
+- Collection of Resources → ``Catalog``
+- Filtered/sorted view of a Catalog → ``Lens``
+- Async fetch lifecycle → ``Job``
+- Selected item identifier → ``Selection``
+- User preference → ``Setting``
+- Secret → ``Credential``
+- SwiftData entity → `@Model` + `@Query` (*not* a Splint type)
+- Presentation state (sheet, alert, popover) → `@State` on the presenter
+- Transition/animation state → `@State` on the animating view
+- Draft/form input → `@State` on the form view
+- Player/media state → dedicated `@Observable` with 1–2 fields
+- Anything else shared across views → small purpose-built `@Observable`
+  with 1–2 fields. If it grows past 3 fields, you've discovered a new
+  category — name it and split it.
+
+## There is no `ViewState` type
+
+If a value doesn't fit one of the types above, it is `@State` on the
+view that owns it. If two views need the same value, make a small
+purpose-built `@Observable` class with 1–2 fields. A general-purpose
+"view state" container becomes a god-object over time; forcing
+decomposition is the point.
+
+## When you *don't* need Splint
+
+If your feature is just `@Query` → `List` → detail, write plain
+SwiftUI. Splint earns its keep when you have remote API resources,
+async lifecycles, preferences, or derived collections.
+
+## SwiftData entities are already correct
+
+`@Model` includes `@Observable`. Pass instances directly to child
+views. Do not wrap them in ViewModels or Splint types. Use `@Query` in
+views. `@Model` types are not `Sendable` and cannot be held in a
+``Catalog``; join `@Query` results with catalog lookups at the view
+level when both are needed.
+
+## Topics
+
+### Related
+
+- <doc:ObservationBoundaries>

--- a/Sources/Splint/Splint.docc/CredentialGuide.md
+++ b/Sources/Splint/Splint.docc/CredentialGuide.md
@@ -1,0 +1,46 @@
+# Credentials
+
+A keychain-backed secret — a struct, not an `@Observable` — read on
+demand at the boundary where it's needed.
+
+## Overview
+
+``Credential`` wraps `SecItem` with the correct add-or-update dance
+and accessibility defaults. Raw keychain code is hostile, and
+agent-produced implementations drift wrong in ways that compile and
+appear to work on the happy path; this wrapper is the canonical form.
+
+It is deliberately a value type. Credentials are read at the API
+boundary that needs them (sign a request, hand a token to a player),
+not watched by views. Storing a secret in an `@Observable` property
+exposes it to every view in that observation scope and encourages
+caching rules that drift out of sync with the keychain.
+
+## Usage
+
+```swift
+let token = Credential(service: "com.example.app", account: "providerToken")
+
+try token.save("abc123")
+let value = try token.read()
+try token.delete()
+```
+
+By default, ``Credential/synchronizable`` is `true` — the credential
+syncs via iCloud Keychain for cross-device convenience. Pass `false`
+for device-local secrets (hardware-bound tokens, device-specific keys):
+
+```swift
+let deviceKey = Credential(
+    service: "com.example.app",
+    account: "deviceKey",
+    synchronizable: false
+)
+```
+
+## Topics
+
+### Related
+
+- ``Setting``
+- <doc:ObservationBoundaries>

--- a/Sources/Splint/Splint.docc/JobGuide.md
+++ b/Sources/Splint/Splint.docc/JobGuide.md
@@ -1,0 +1,87 @@
+# Jobs for one-shot async work
+
+An observable async-operation lifecycle. Replaces the ad hoc
+`isLoading` / `error` / `data` trio that tends to drift onto a view
+model and become a god-object seed.
+
+## Overview
+
+``Job`` exposes two stored properties — ``Job/phase`` (lifecycle) and
+``Job/value`` (result) — that are observed independently. Views reading
+only one do not re-evaluate when the other changes.
+
+## Usage
+
+```swift
+let metadataJob = Job<Metadata>()
+
+.task {
+    metadataJob.run { try await client.fetchMetadata(book.id) }
+}
+```
+
+## Closures and isolation
+
+``Job/run(_:)``'s task closure runs in its own `Task`. Because the
+parameter is `sending`
+([SE-0430](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0430-transferring-parameters-and-results.md)),
+the closure can capture non-`Sendable` values at the call site —
+including `self` of a SwiftUI `View`, whose property wrappers usually
+make the enclosing struct non-`Sendable`. Region-based isolation
+accepts the closure's disconnected copy of the captured values.
+
+Capture whatever's needed — a `Sendable` service, `self`'s init-time
+`let` properties, a value-type input. What to avoid inside the closure
+body:
+
+- Reading `@State`, `@Query` results, or `@Environment` values from
+  inside the closure body. Even when the capture compiles, you get a
+  frozen snapshot taken when the closure was created — later wrapper
+  updates are invisible. Capture the specific IDs or scalars you need
+  at the call site instead.
+- Mutating `@MainActor` state directly. The `Task` runs off the main
+  actor, so the compiler usually blocks this. When you genuinely need
+  to mutate main-actor state after the `await`, hop back explicitly:
+
+```swift
+metadataJob.run {
+    let fresh = try await client.fetchMetadata(book.id)
+    await MainActor.run { cache[book.id] = fresh }
+    return fresh
+}
+```
+
+Patterns that work well:
+
+```swift
+// ✅ Capture self; read stable init-time `let` properties.
+.task {
+    metadataJob.run { try await client.fetchMetadata(book.id) }
+}
+
+// ✅ Equivalent; explicit capture for readability.
+.task {
+    let client = client
+    let id = book.id
+    metadataJob.run { try await client.fetchMetadata(id) }
+}
+
+// ❌ Reads @Query results inside the Task. `sending` may allow the
+// capture, but `favorites` is a snapshot frozen at closure creation —
+// later @Query updates never reach this closure. Pull what you need
+// out at the call site and pass it in as a scalar.
+.task {
+    metadataJob.run {
+        let fav = favorites.contains { $0.bookID == book.id }
+        return try await client.fetchMetadata(for: book.id, favorited: fav)
+    }
+}
+```
+
+## Topics
+
+### Related
+
+- ``Phase``
+- ``Catalog``
+- <doc:ObservationBoundaries>

--- a/Sources/Splint/Splint.docc/JobGuide.md
+++ b/Sources/Splint/Splint.docc/JobGuide.md
@@ -22,7 +22,7 @@ let metadataJob = Job<Metadata>()
 
 ## Closures and isolation
 
-``Job/run(_:)``'s task closure runs in its own `Task`. Because the
+``Job/run(priority:task:)``'s task closure runs in its own `Task`. Because the
 parameter is `sending`
 ([SE-0430](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0430-transferring-parameters-and-results.md)),
 the closure can capture non-`Sendable` values at the call site —

--- a/Sources/Splint/Splint.docc/LensGuide.md
+++ b/Sources/Splint/Splint.docc/LensGuide.md
@@ -1,0 +1,64 @@
+# Lenses over a catalog
+
+A derived, read-only view over a ``Catalog`` — filtering, sorting, or
+both — kept in sync automatically.
+
+## Overview
+
+A ``Lens`` watches its source catalog's `items` and recomputes its own
+projection when the source changes or when the filter/sort predicates
+change. The source's `Criteria` type is erased at init: call sites see
+`Lens<Channel>`, not `Lens<Channel, ProviderCriteria>`.
+
+Reach for a lens instead of maintaining a parallel array synced by
+hand. Duplicate arrays are one of the bugs ``Lens`` exists to prevent.
+
+## Usage
+
+```swift
+let favorites = Lens<Book>(source: catalog, filter: { $0.isFavorite })
+```
+
+## Performance
+
+`Lens` recomputes the full projection when the source catalog's items
+change — O(n) for the filter pass, plus O(n log n) for the sort
+(stdlib introsort) when one is set. Under ~1k items this is
+negligible. For larger datasets, consider whether filtering belongs in
+the fetch closure (server-side filtering via the catalog's `Criteria`)
+rather than in a client-side lens.
+
+## Closures capture once
+
+``Lens`` captures `filter` and `sort` at init. They re-run only on
+`updateFilter` / `updateSort` — not when variables they reference
+change. Capturing mutable view state at init compiles and looks
+correct, and fails silently:
+
+```swift
+// ❌ minRating capture goes stale — Lens never sees changes
+@State private var minRating = 0
+@State private var lens = Lens(source: catalog, filter: { $0.rating >= minRating })
+
+// ✅ Drive updates explicitly
+@State private var minRating = 0
+@State private var lens = Lens(source: catalog)
+
+var body: some View {
+    BookListView(lens: lens)
+        .onChange(of: minRating) { _, new in
+            lens.updateFilter { $0.rating >= new }
+        }
+}
+```
+
+Same rule as ``Catalog``'s fetch closure: Splint closures capture at
+construction; mutable inputs flow through update methods.
+
+## Topics
+
+### Related
+
+- ``Catalog``
+- ``Resource``
+- <doc:ObservationBoundaries>

--- a/Sources/Splint/Splint.docc/PhaseGuide.md
+++ b/Sources/Splint/Splint.docc/PhaseGuide.md
@@ -1,0 +1,39 @@
+# Phases
+
+The lifecycle shared by ``Catalog`` and ``Job``: idle, running,
+completed, failed.
+
+## Overview
+
+``Phase`` is the one shared lifecycle across Splint's async types.
+Both ``Catalog`` and ``Job`` expose `phase` as a stored property; a
+view that cares only about *how* a fetch is going can observe `phase`
+without observing the result.
+
+Phase intentionally carries no associated result. The value produced
+by a successful operation lives alongside the phase (for example
+``Catalog``'s `items`, ``Job``'s `value`) so that views reading only
+one need not observe the other. This is the same split that enables
+fine-grained observation elsewhere in the library: separate fields,
+separate boundaries.
+
+## Cases
+
+- ``Phase/idle`` — no work has started.
+- ``Phase/running`` — work is in flight.
+- ``Phase/completed`` — work finished successfully.
+- ``Phase/failed(_:)`` — work failed. The associated value is a
+  user-presentable message.
+
+The failure associated value is a plain `String`, deliberately. A
+`Phase` needs to be `Equatable` and `Sendable`, and views almost
+always want to show a message, not introspect an error type. When a
+caller needs structured diagnostics, surface them alongside the phase
+rather than inside it.
+
+## Topics
+
+### Related
+
+- ``Catalog``
+- ``Job``

--- a/Sources/Splint/Splint.docc/ResourceGuide.md
+++ b/Sources/Splint/Splint.docc/ResourceGuide.md
@@ -1,0 +1,42 @@
+# Resources
+
+A marker protocol bundling the conformances every decoded remote value
+needs.
+
+## Overview
+
+``Resource`` composes `Identifiable`, `Sendable`, `Equatable`, and
+`Hashable` — the conformances a value needs to appear in `ForEach`,
+cross async boundaries, diff inside collections, and travel as a
+`NavigationLink` value. It exists so that agents (and humans) can
+write `struct Channel: Resource` instead of remembering which
+protocols to adopt.
+
+## Usage
+
+```swift
+struct Book: Resource {
+    let id: String
+    let title: String
+    let author: String
+}
+```
+
+## What's deliberately absent
+
+`Decodable` is *not* included. Not every resource arrives from JSON —
+some come from a parser, a database, or a platform API. Conformers
+that need decoding add `Decodable` or `Codable` themselves.
+
+The protocol is intentionally minimal. Adding conformances here would
+force every resource in every consumer to satisfy them, for a gain
+that almost never matches the cost. When a specific family of
+resources needs more (for example `Sendable & Codable & Comparable`),
+layer it on the concrete type.
+
+## Topics
+
+### Related
+
+- ``Catalog``
+- ``Lens``

--- a/Sources/Splint/Splint.docc/SelectionGuide.md
+++ b/Sources/Splint/Splint.docc/SelectionGuide.md
@@ -1,0 +1,38 @@
+# Selections
+
+A one-value observable for the currently selected item identifier,
+scoped to a single selectable concern.
+
+## Overview
+
+A ``Selection`` holds one optional identifier. One per concern —
+active channel, active tab, highlighted row — each its own observation
+boundary. The type literally cannot hold more than one value, which
+structurally prevents the god-object drift you get when `selectedItem`
+lives on a catch-all `@Observable` next to fourteen unrelated fields.
+
+Store identifiers, not entities. When the view needs the full entity,
+look it up via the owning ``Catalog`` or `@Query`.
+
+## Usage
+
+```swift
+@State private var selectedChannel = Selection<Channel.ID>()
+
+var body: some View {
+    List(channels, selection: Binding(
+        get: { selectedChannel.current },
+        set: { selectedChannel.current = $0 }
+    )) { channel in
+        Text(channel.name)
+    }
+}
+```
+
+## Topics
+
+### Related
+
+- ``Catalog``
+- ``Resource``
+- <doc:ObservationBoundaries>

--- a/Sources/Splint/Splint.docc/SettingGuide.md
+++ b/Sources/Splint/Splint.docc/SettingGuide.md
@@ -1,0 +1,57 @@
+# Settings
+
+A single typed user preference backed by `UserDefaults`, with live
+cross-instance and cross-process sync.
+
+## Overview
+
+Prefer many small ``Setting`` instances over a single "settings
+object." Each ``Setting`` is its own observation point, so views
+reading one preference do not re-evaluate when an unrelated preference
+changes. One key, one type, one observation boundary.
+
+## Usage
+
+```swift
+let playbackRate = Setting<Double>("playbackRate", default: 1.0)
+let autoplay = Setting<Bool>("autoplay", default: true)
+```
+
+`RawRepresentable` enums are supported via a convenience initializer
+that reads and writes the raw value — a previously-persisted enum
+setting round-trips correctly instead of silently falling back to the
+default:
+
+```swift
+enum Theme: String, SettingValue { case light, dark, system }
+
+let theme = Setting<Theme>("theme", default: .system)
+```
+
+## Sync across instances and processes
+
+``Setting`` observes its key via `UserDefaults` key-value observation,
+so:
+
+- **Multiple instances on the same key stay in sync.** Two settings
+  bound to the same key/store see each other's writes automatically.
+  No "single owner per key" convention is required — instance count is
+  a perf footnote, not a correctness concern.
+- **App Group suites sync across processes.** A setting backed by
+  `UserDefaults(suiteName: "group.example.shared")` stays in sync
+  between the host app and its extensions (widgets, intents, share
+  extensions). This is Apple's `userdefaultsd` behavior for
+  entitlement-granted App Groups, surfaced through standard KVO —
+  Splint adds no code of its own for cross-process notification.
+
+Splint guards against KVO re-entry: when an external write delivers a
+value through the observer, the setting updates `value` without
+writing back. A naive round-trip would bounce indefinitely.
+
+## Topics
+
+### Related
+
+- ``SettingValue``
+- ``Credential``
+- <doc:ObservationBoundaries>

--- a/Sources/Splint/Splint.docc/SettingValueGuide.md
+++ b/Sources/Splint/Splint.docc/SettingValueGuide.md
@@ -1,0 +1,43 @@
+# Setting values
+
+The marker protocol identifying value types that ``Setting`` can
+persist safely through `UserDefaults`.
+
+## Overview
+
+``SettingValue`` constrains ``Setting``'s generic parameter to types
+that `UserDefaults` supports natively. The protocol refines
+`Sendable & Equatable`, so every persisted preference can cross actor
+boundaries and suppress redundant observation cycles when an external
+KVO callback delivers a value that already matches.
+
+Conforming types:
+
+- `Bool`, `Int`, `Double`, `Float`
+- `String`, `Data`, `Date`
+- `Array<Element>` where `Element: SettingValue`
+- `Dictionary<String, Value>` where `Value: SettingValue`
+
+A ``Setting`` whose `Value` is a `RawRepresentable` enum whose
+`RawValue` conforms to ``SettingValue`` gets a convenience initializer
+that reads and writes via `rawValue`.
+
+## What's deliberately absent
+
+- **`URL`** — `UserDefaults` archives URLs via `NSKeyedArchiver`, so
+  a plain `object(forKey:) as? URL` round-trip fails silently. Store
+  URLs as `String` and parse at the boundary that needs them.
+- **`Codable` structs** — encoding arbitrary structs into `Data` and
+  stashing them in `UserDefaults` is an anti-pattern. It bypasses the
+  store's schema guarantees, makes migrations implicit, and blurs the
+  line between user preferences and app state. Use SwiftData for
+  structured persistence.
+
+Both exclusions are deliberate, not oversights. Widening the protocol
+would make the wrong thing easy.
+
+## Topics
+
+### Related
+
+- ``Setting``

--- a/Sources/Splint/Splint.docc/Splint.md
+++ b/Sources/Splint/Splint.docc/Splint.md
@@ -26,27 +26,41 @@ observation. Pass model instances directly to child views.
 
 ## Topics
 
+### Core concepts
+
+- <doc:ChoosingTheRightType>
+- <doc:ObservationBoundaries>
+
 ### Modeling remote data
 
+- <doc:ResourceGuide>
 - ``Resource``
+- <doc:CatalogGuide>
 - ``Catalog``
 - ``NoCriteria``
 
 ### Deriving views over a Catalog
 
+- <doc:LensGuide>
 - ``Lens``
 
 ### Async operation lifecycle
 
+- <doc:PhaseGuide>
 - ``Phase``
+- <doc:JobGuide>
 - ``Job``
 
 ### User-facing state
 
+- <doc:SelectionGuide>
 - ``Selection``
+- <doc:SettingGuide>
 - ``Setting``
+- <doc:SettingValueGuide>
 - ``SettingValue``
 
 ### Secrets
 
+- <doc:CredentialGuide>
 - ``Credential``


### PR DESCRIPTION
## Summary

- Adds a conceptual DocC article for each public primitive under `Sources/Splint/Splint.docc/` — `CatalogGuide`, `LensGuide`, `JobGuide`, `SelectionGuide`, `SettingGuide`, `CredentialGuide`, `PhaseGuide`, `ResourceGuide`, `SettingValueGuide` — plus a top-level `ChoosingTheRightType` article.
- Ports the deep prose currently trapped in `README.md` (load vs refresh, Lens closure capture, Job isolation, Setting KVO sync, deliberate-omission rationale on `Resource` / `SettingValue`) into DocC where Swift Package Index will actually render it.
- Expands the landing page's `## Topics` to surface each article alongside its symbol.

Closes #20.

## Why

`CLAUDE.md` declares DocC as the source of truth and SPI as the only hosted docs target, but the catalog previously contained just the landing page and one concept article. SPI doesn't render `README.md`, so readers landing on the hosted docs missed everything that makes the library usable. This re-homes the prose; `README.md` is untouched (per the issue's "non-goals").

## Notes for reviewers

- Article filenames use a `-Guide` suffix (e.g. `CatalogGuide.md`) because DocC drops articles whose filename matches a symbol name (rdar://79745455). The first build produced collision warnings; renaming cleared them.
- No public API changes. No symbol-level `///` comments were touched.
- Verified with `xcodebuild docbuild` (clean, apart from pre-existing `Resource.swift` symbol-link warnings on `Identifiable`/`Sendable`/`Equatable`/`Hashable` that pre-date this PR) and `script/test` (22 tests, 4 suites, all pass).

## Test plan

- [ ] `xcodebuild docbuild -scheme Splint -destination 'generic/platform=macOS'` builds with no new warnings.
- [ ] `script/test` passes.
- [ ] Post-merge: check the SPI docs page surfaces the new articles under their Topics groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)