### PR TITLE
Demonstrate Credential in the Bookshelf example (#21)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,3 +44,25 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 
+      # The code-review plugin exits 0 regardless of findings by design —
+      # see https://code.claude.com/docs/en/code-review ("never blocks
+      # merging through branch protection rules"). We want the check to
+      # fail if any issues were flagged, so parse the plugin's final
+      # result text out of the execution file and fail on a non-zero
+      # issue count.
+      - name: Fail if review flagged issues
+        if: always() && steps.claude-review.outcome == 'success'
+        run: |
+          FILE="${{ steps.claude-review.outputs.execution_file }}"
+          if [ -z "$FILE" ] || [ ! -f "$FILE" ]; then
+            echo "::warning::No execution_file output from claude-review; skipping gate"
+            exit 0
+          fi
+          RESULT=$(jq -r '.result // ""' "$FILE")
+          echo "Claude review result:"
+          echo "$RESULT"
+          if echo "$RESULT" | grep -qiE "[1-9][0-9]* issues? found"; then
+            echo "::error::Claude Code Review flagged issues — see PR comment"
+            exit 1
+          fi
+

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -58,7 +58,7 @@ jobs:
             echo "::warning::No execution_file output from claude-review; skipping gate"
             exit 0
           fi
-          RESULT=$(jq -r '.result // ""' "$FILE")
+          RESULT=$(jq -r 'map(select(.type == "result")) | .[0].result // ""' "$FILE")
           echo "Claude review result:"
           echo "$RESULT"
           if echo "$RESULT" | grep -qiE "[1-9][0-9]* issues? found"; then

--- a/Example/Bookshelf/BookCatalog+Environment.swift
+++ b/Example/Bookshelf/BookCatalog+Environment.swift
@@ -13,4 +13,5 @@ extension EnvironmentValues {
   @Entry public var bookSelection: Selection<String>? = nil
   @Entry public var showCoversSetting: Setting<Bool>? = nil
   @Entry public var preferredGenreSetting: Setting<String>? = nil
+  @Entry public var apiCredentialStatus: CredentialStatus? = nil
 }

--- a/Example/Bookshelf/BookClient.swift
+++ b/Example/Bookshelf/BookClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Splint
 
 /// Injected API. A closure struct — no protocol, no DI container, no
 /// singleton. `.mock` returns hardcoded books after a short delay so the
@@ -35,8 +36,34 @@ extension BookClient {
     }
   )
 
-  /// Placeholder "real" client — wire in a URLSession here in a real app.
-  public static let live = mock
+  /// "Real" client shape — reads the keychain-backed API token on every
+  /// call (not cached) to prove `Credential` composes with request-time
+  /// auth. The response body is still mocked because the example app has
+  /// no network dependency; a production client would attach `token` to
+  /// an `Authorization` header on a real `URLRequest` here.
+  public static let live = BookClient(
+    fetchBooks: { _ in
+      _ = try? Credential(
+        service: bookshelfCredentialService,
+        account: bookshelfCredentialAccount,
+        synchronizable: false
+      ).read()
+      try? await Task.sleep(for: .milliseconds(50))
+      return sampleBooks
+    },
+    fetchMetadata: { id in
+      _ = try? Credential(
+        service: bookshelfCredentialService,
+        account: bookshelfCredentialAccount,
+        synchronizable: false
+      ).read()
+      try? await Task.sleep(for: .milliseconds(50))
+      return BookMetadata(
+        description: "A fine book about \(id).",
+        pageCount: 200 + (abs(id.hashValue) % 400)
+      )
+    }
+  )
 
   static let sampleBooks: [Book] = [
     Book(id: "1", title: "The Pragmatic Programmer", author: "Hunt & Thomas", genre: "Nonfiction", year: 1999),

--- a/Example/Bookshelf/ContentView.swift
+++ b/Example/Bookshelf/ContentView.swift
@@ -14,6 +14,13 @@ public struct ContentView: View {
   @State private var selection = Selection<String>()
   @State private var showCovers = Setting<Bool>("showCovers", default: true)
   @State private var preferredGenre = Setting<String>("preferredGenre", default: "All")
+  @State private var apiCredentialStatus = CredentialStatus(
+    credential: Credential(
+      service: bookshelfCredentialService,
+      account: bookshelfCredentialAccount,
+      synchronizable: false
+    )
+  )
 
   public init(client: BookClient) {
     self.client = client
@@ -52,7 +59,9 @@ public struct ContentView: View {
     .environment(\.bookSelection, selection)
     .environment(\.showCoversSetting, showCovers)
     .environment(\.preferredGenreSetting, preferredGenre)
+    .environment(\.apiCredentialStatus, apiCredentialStatus)
     .task {
+      apiCredentialStatus.refresh()
       catalog.load(BookCriteria(libraryID: "main"))
     }
     // `initial: true` is load-bearing: `Setting` reads from UserDefaults

--- a/Example/Bookshelf/CredentialStore.swift
+++ b/Example/Bookshelf/CredentialStore.swift
@@ -23,6 +23,15 @@ public final class CredentialStatus {
   public private(set) var state: State = .unknown
   public let credential: Credential
 
+  /// `true` only when a value is known to be stored. Views should gate
+  /// destructive actions (like "Clear") on this so we never try to
+  /// delete from the `.unknown` pre-refresh state or the `.notSet`
+  /// state, both of which would produce no-op or error output.
+  public var canClear: Bool {
+    if case .saved = state { return true }
+    return false
+  }
+
   public init(credential: Credential) {
     self.credential = credential
   }

--- a/Example/Bookshelf/CredentialStore.swift
+++ b/Example/Bookshelf/CredentialStore.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Splint
+
+/// `kSecAttrService` for the Bookshelf demo credential. Grouped under the
+/// app's bundle identifier so it can't collide with other services.
+public let bookshelfCredentialService = "co.searls.splint.Bookshelf"
+/// `kSecAttrAccount` for the Bookshelf demo API token.
+public let bookshelfCredentialAccount = "api-token"
+
+/// Observable status for a single `Credential`. Views read `state` and call
+/// `save`/`clear`/`refresh`; the throwing keychain surface stays inside this
+/// type so SwiftUI never sees a `throws` in a binding path.
+@MainActor
+@Observable
+public final class CredentialStatus {
+  public enum State: Equatable {
+    case unknown
+    case saved
+    case notSet
+    case error(String)
+  }
+
+  public private(set) var state: State = .unknown
+  public let credential: Credential
+
+  public init(credential: Credential) {
+    self.credential = credential
+  }
+
+  public func refresh() {
+    do {
+      state = (try credential.read() != nil) ? .saved : .notSet
+    } catch {
+      state = .error(String(describing: error))
+    }
+  }
+
+  public func save(_ value: String) {
+    do {
+      try credential.save(value)
+      state = .saved
+    } catch {
+      state = .error(String(describing: error))
+    }
+  }
+
+  public func clear() {
+    do {
+      try credential.delete()
+      state = .notSet
+    } catch {
+      state = .error(String(describing: error))
+    }
+  }
+}

--- a/Example/Bookshelf/SettingsView.swift
+++ b/Example/Bookshelf/SettingsView.swift
@@ -1,5 +1,10 @@
 import SwiftUI
 import Splint
+#if canImport(UIKit)
+  import UIKit
+#elseif canImport(AppKit)
+  import AppKit
+#endif
 
 /// Two `Setting` instances — one `Bool`, one `String` — each observed
 /// independently via `@Bindable`. There is no `SettingsStore`: each
@@ -43,13 +48,28 @@ public struct SettingsView: View {
           }
         }
       }
-      Section("API") {
+      Section {
         if let apiCredentialStatus {
           APITokenRow(status: apiCredentialStatus)
+        }
+      } header: {
+        Text("API")
+      } footer: {
+        if let apiCredentialStatus {
+          Text(Self.statusText(for: apiCredentialStatus.state))
         }
       }
     }
     .navigationTitle("Settings")
+  }
+
+  static func statusText(for state: CredentialStatus.State) -> String {
+    switch state {
+    case .unknown: return "…"
+    case .saved: return "Saved"
+    case .notSet: return "Not set"
+    case .error(let message): return "Error: \(message)"
+    }
   }
 }
 
@@ -60,29 +80,37 @@ private struct APITokenRow: View {
   @State private var draft = ""
 
   var body: some View {
-    SecureField("API token", text: $draft)
+    LabeledContent("API token") {
+      SecureField("Enter token", text: $draft)
+        .multilineTextAlignment(.trailing)
+    }
     HStack {
       Button("Save") {
         status.save(draft)
         draft = ""
+        announce(SettingsView.statusText(for: status.state))
       }
       .disabled(draft.isEmpty)
       Button("Clear", role: .destructive) {
         status.clear()
+        announce(SettingsView.statusText(for: status.state))
       }
       .disabled(status.state == .notSet)
     }
-    Text(statusText)
-      .font(.footnote)
-      .foregroundStyle(.secondary)
   }
 
-  private var statusText: String {
-    switch status.state {
-    case .unknown: return "…"
-    case .saved: return "Saved"
-    case .notSet: return "Not set"
-    case .error(let message): return "Error: \(message)"
-    }
+  /// Posts a VoiceOver announcement so blind users hear the save/clear
+  /// result immediately. SwiftUI has no stable cross-platform live-region
+  /// modifier, so we post via the platform accessibility APIs.
+  private func announce(_ message: String) {
+    #if canImport(UIKit)
+      UIAccessibility.post(notification: .announcement, argument: message)
+    #elseif canImport(AppKit)
+      NSAccessibility.post(
+        element: NSApp as Any,
+        notification: .announcementRequested,
+        userInfo: [.announcement: message, .priority: NSAccessibilityPriorityLevel.medium.rawValue]
+      )
+    #endif
   }
 }

--- a/Example/Bookshelf/SettingsView.swift
+++ b/Example/Bookshelf/SettingsView.swift
@@ -87,7 +87,7 @@ private struct APITokenRow: View {
     HStack {
       Button("Save") {
         status.save(draft)
-        draft = ""
+        if status.state == .saved { draft = "" }
         announce(SettingsView.statusText(for: status.state))
       }
       .disabled(draft.isEmpty)

--- a/Example/Bookshelf/SettingsView.swift
+++ b/Example/Bookshelf/SettingsView.swift
@@ -95,7 +95,7 @@ private struct APITokenRow: View {
         status.clear()
         announce(SettingsView.statusText(for: status.state))
       }
-      .disabled(status.state == .notSet)
+      .disabled(!status.canClear)
     }
   }
 

--- a/Example/Bookshelf/SettingsView.swift
+++ b/Example/Bookshelf/SettingsView.swift
@@ -9,6 +9,7 @@ public struct SettingsView: View {
   @Environment(\.showCoversSetting) private var showCovers
   @Environment(\.preferredGenreSetting) private var preferredGenre
   @Environment(\.bookCatalog) private var catalog
+  @Environment(\.apiCredentialStatus) private var apiCredentialStatus
 
   public init() {}
 
@@ -42,7 +43,46 @@ public struct SettingsView: View {
           }
         }
       }
+      Section("API") {
+        if let apiCredentialStatus {
+          APITokenRow(status: apiCredentialStatus)
+        }
+      }
     }
     .navigationTitle("Settings")
+  }
+}
+
+/// Demonstrates `Credential` as a device-local keychain round-trip. Holds a
+/// transient `draft` so the `SecureField` doesn't bind to the saved value.
+private struct APITokenRow: View {
+  let status: CredentialStatus
+  @State private var draft = ""
+
+  var body: some View {
+    SecureField("API token", text: $draft)
+    HStack {
+      Button("Save") {
+        status.save(draft)
+        draft = ""
+      }
+      .disabled(draft.isEmpty)
+      Button("Clear", role: .destructive) {
+        status.clear()
+      }
+      .disabled(status.state == .notSet)
+    }
+    Text(statusText)
+      .font(.footnote)
+      .foregroundStyle(.secondary)
+  }
+
+  private var statusText: String {
+    switch status.state {
+    case .unknown: return "…"
+    case .saved: return "Saved"
+    case .notSet: return "Not set"
+    case .error(let message): return "Error: \(message)"
+    }
   }
 }

--- a/Example/BookshelfTests/CredentialIntegrationTests.swift
+++ b/Example/BookshelfTests/CredentialIntegrationTests.swift
@@ -23,6 +23,24 @@ struct CredentialIntegrationTests {
     return (CredentialStatus(credential: cred), backend)
   }
 
+  @Test func canClearIsFalseInUnknownState() {
+    let (status, _) = makeStatus()
+    // State is .unknown until refresh() runs.
+    #expect(status.canClear == false)
+  }
+
+  @Test func canClearIsFalseAfterRefreshWithNoStoredToken() {
+    let (status, _) = makeStatus()
+    status.refresh()
+    #expect(status.canClear == false)
+  }
+
+  @Test func canClearIsTrueAfterSave() {
+    let (status, _) = makeStatus()
+    status.save("secret-token")
+    #expect(status.canClear == true)
+  }
+
   @Test func refreshWithNoStoredTokenReportsNotSet() {
     let (status, _) = makeStatus()
     status.refresh()

--- a/Example/BookshelfTests/CredentialIntegrationTests.swift
+++ b/Example/BookshelfTests/CredentialIntegrationTests.swift
@@ -60,6 +60,24 @@ struct CredentialIntegrationTests {
       Issue.record("expected .error state, got \(String(describing: status.state))")
     }
   }
+
+  @Test func refreshSurfacesBackendErrorsInState() {
+    let backend = FailingBackend(readStatus: errSecAuthFailed)
+    let (status, _) = makeStatus(backend: backend)
+    status.refresh()
+    if case .error = status.state { /* ok */ } else {
+      Issue.record("expected .error state, got \(String(describing: status.state))")
+    }
+  }
+
+  @Test func clearSurfacesBackendErrorsInState() {
+    let backend = FailingBackend(deleteStatus: errSecAuthFailed)
+    let (status, _) = makeStatus(backend: backend)
+    status.clear()
+    if case .error = status.state { /* ok */ } else {
+      Issue.record("expected .error state, got \(String(describing: status.state))")
+    }
+  }
 }
 
 // MARK: - Test backends
@@ -102,17 +120,20 @@ private final class InMemoryBackend: CredentialBackend, @unchecked Sendable {
 }
 
 private struct FailingBackend: CredentialBackend {
+  var readStatus: OSStatus = errSecItemNotFound
   var addStatus: OSStatus = errSecSuccess
+  var updateStatus: OSStatus = errSecSuccess
+  var deleteStatus: OSStatus = errSecSuccess
   func read(service: String, account: String, synchronizable: Bool)
     -> (status: OSStatus, data: Data?)
-  { (errSecItemNotFound, nil) }
+  { (readStatus, nil) }
   func add(service: String, account: String, synchronizable: Bool, data: Data) -> OSStatus {
     addStatus
   }
   func update(service: String, account: String, synchronizable: Bool, data: Data) -> OSStatus {
-    errSecSuccess
+    updateStatus
   }
   func delete(service: String, account: String, synchronizable: Bool) -> OSStatus {
-    errSecSuccess
+    deleteStatus
   }
 }

--- a/Example/BookshelfTests/CredentialIntegrationTests.swift
+++ b/Example/BookshelfTests/CredentialIntegrationTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Security
+import Testing
+
+@_spi(Testing) import Splint
+@testable import Bookshelf
+
+/// Drives the same round-trip the Settings UI drives: save → read → delete,
+/// using an injected in-memory `CredentialBackend` so CI doesn't touch the
+/// real keychain.
+@MainActor
+@Suite("Bookshelf credential integration")
+struct CredentialIntegrationTests {
+  private func makeStatus(backend: any CredentialBackend = InMemoryBackend())
+    -> (status: CredentialStatus, backend: any CredentialBackend)
+  {
+    let cred = Credential(
+      service: "co.searls.bookshelf.tests",
+      account: "api-token",
+      synchronizable: false,
+      backend: backend
+    )
+    return (CredentialStatus(credential: cred), backend)
+  }
+
+  @Test func refreshWithNoStoredTokenReportsNotSet() {
+    let (status, _) = makeStatus()
+    status.refresh()
+    #expect(status.state == .notSet)
+  }
+
+  @Test func saveThenRefreshReportsSaved() {
+    let (status, _) = makeStatus()
+    status.save("secret-token")
+    #expect(status.state == .saved)
+    status.refresh()
+    #expect(status.state == .saved)
+  }
+
+  @Test func clearResetsStatusToNotSet() {
+    let (status, _) = makeStatus()
+    status.save("secret-token")
+    status.clear()
+    #expect(status.state == .notSet)
+  }
+
+  @Test func saveOverwritesPreviousValue() {
+    let backend = InMemoryBackend()
+    let (status, _) = makeStatus(backend: backend)
+    status.save("first")
+    status.save("second")
+    #expect(backend.currentValue() == "second")
+  }
+
+  @Test func saveSurfacesBackendErrorsInState() {
+    let backend = FailingBackend(addStatus: errSecAuthFailed)
+    let (status, _) = makeStatus(backend: backend)
+    status.save("secret-token")
+    if case .error = status.state { /* ok */ } else {
+      Issue.record("expected .error state, got \(String(describing: status.state))")
+    }
+  }
+}
+
+// MARK: - Test backends
+
+/// Thread-unsafe by design — tests are `@MainActor`-serialized and each test
+/// gets its own instance.
+private final class InMemoryBackend: CredentialBackend, @unchecked Sendable {
+  private var storage: [String: Data] = [:]
+  private func key(_ service: String, _ account: String, _ sync: Bool) -> String {
+    "\(service)|\(account)|\(sync)"
+  }
+  func currentValue() -> String? {
+    storage.values.first.flatMap { String(data: $0, encoding: .utf8) }
+  }
+  func read(service: String, account: String, synchronizable: Bool)
+    -> (status: OSStatus, data: Data?)
+  {
+    if let data = storage[key(service, account, synchronizable)] {
+      return (errSecSuccess, data)
+    }
+    return (errSecItemNotFound, nil)
+  }
+  func add(service: String, account: String, synchronizable: Bool, data: Data) -> OSStatus {
+    let k = key(service, account, synchronizable)
+    if storage[k] != nil { return errSecDuplicateItem }
+    storage[k] = data
+    return errSecSuccess
+  }
+  func update(service: String, account: String, synchronizable: Bool, data: Data) -> OSStatus {
+    let k = key(service, account, synchronizable)
+    guard storage[k] != nil else { return errSecItemNotFound }
+    storage[k] = data
+    return errSecSuccess
+  }
+  func delete(service: String, account: String, synchronizable: Bool) -> OSStatus {
+    let k = key(service, account, synchronizable)
+    if storage.removeValue(forKey: k) == nil { return errSecItemNotFound }
+    return errSecSuccess
+  }
+}
+
+private struct FailingBackend: CredentialBackend {
+  var addStatus: OSStatus = errSecSuccess
+  func read(service: String, account: String, synchronizable: Bool)
+    -> (status: OSStatus, data: Data?)
+  { (errSecItemNotFound, nil) }
+  func add(service: String, account: String, synchronizable: Bool, data: Data) -> OSStatus {
+    addStatus
+  }
+  func update(service: String, account: String, synchronizable: Bool, data: Data) -> OSStatus {
+    errSecSuccess
+  }
+  func delete(service: String, account: String, synchronizable: Bool) -> OSStatus {
+    errSecSuccess
+  }
+}

--- a/Example/BookshelfTests/CredentialIntegrationTests.swift
+++ b/Example/BookshelfTests/CredentialIntegrationTests.swift
@@ -29,10 +29,15 @@ struct CredentialIntegrationTests {
     #expect(status.state == .notSet)
   }
 
-  @Test func saveThenRefreshReportsSaved() {
+  @Test func saveReportsSaved() {
     let (status, _) = makeStatus()
     status.save("secret-token")
     #expect(status.state == .saved)
+  }
+
+  @Test func refreshAfterSaveReportsSaved() {
+    let (status, _) = makeStatus()
+    status.save("secret-token")
     status.refresh()
     #expect(status.state == .saved)
   }
@@ -44,12 +49,11 @@ struct CredentialIntegrationTests {
     #expect(status.state == .notSet)
   }
 
-  @Test func saveOverwritesPreviousValue() {
-    let backend = InMemoryBackend()
-    let (status, _) = makeStatus(backend: backend)
+  @Test func saveOverwritesPreviousValue() throws {
+    let (status, _) = makeStatus()
     status.save("first")
     status.save("second")
-    #expect(backend.currentValue() == "second")
+    #expect(try status.credential.read() == "second")
   }
 
   @Test func saveSurfacesBackendErrorsInState() {
@@ -88,9 +92,6 @@ private final class InMemoryBackend: CredentialBackend, @unchecked Sendable {
   private var storage: [String: Data] = [:]
   private func key(_ service: String, _ account: String, _ sync: Bool) -> String {
     "\(service)|\(account)|\(sync)"
-  }
-  func currentValue() -> String? {
-    storage.values.first.flatMap { String(data: $0, encoding: .utf8) }
   }
   func read(service: String, account: String, synchronizable: Bool)
     -> (status: OSStatus, data: Data?)

--- a/Example/README.md
+++ b/Example/README.md
@@ -36,7 +36,7 @@ source files — there's no duplication.
 | `Selection<String>` | Active book id, bound to `List(selection:)` |
 | `Setting<Bool>` | `"showCovers"` toggle |
 | `Setting<String>` | `"preferredGenre"` filter, persisted across launches |
-| `Credential` | (Not surfaced in UI; `BookClient.live` can read an API token) |
+| `Credential` | Settings → API: save/clear a device-local token; `BookClient.live` reads it per request |
 | `@Model` + `@Query` | `Favorite` — SwiftData, joined to the `Catalog` by id |
 
 ## What it does *not* demonstrate


### PR DESCRIPTION
Closes #21.

## Summary

- New **Settings → API** section with a `LabeledContent`-wrapped `SecureField`, Save/Clear buttons, and a status footer ("Saved" / "Not set" / error).
- `BookClient.live` now reads the keychain-backed token on every fetch (not cached) — proves the "read on demand" semantic honestly. Response body stays mocked; the example has no real network.
- `CredentialStatus` is a small `@MainActor @Observable` wrapper that keeps the throwing keychain surface off SwiftUI binding paths and exposes a non-throwing `state` enum.
- Integration tests inject an in-memory `CredentialBackend` via `@_spi(Testing)` so CI never touches the real keychain. 6 new tests cover set/read/clear/overwrite plus all three error branches (save/refresh/clear).
- README table row updated to reflect surfaced usage.

## Design decisions

- **`synchronizable: false`** — device-local only. Sidesteps iCloud Keychain requirements, which would need a real team identity and `keychain-access-groups` entitlement. Ad-hoc signing on macOS + iOS Simulator is sufficient with the app's bundle id as the implicit access group.
- **No new entitlements file.** The example README already promises "signs to run locally (no development team required)" and we preserve that.
- **VoiceOver announcements** are posted via `UIAccessibility.post` / `NSAccessibility.post` from the Save/Clear button closures. SwiftUI has no stable cross-platform live-region modifier on Splint's target SDKs.
- **Draft preserved on save failure** — the `SecureField` only clears when `status.state == .saved` so a keychain error doesn't force the user to retype.

## Test plan

- [x] `./script/test` — full suite (library + example) passes; library's real-keychain `CredentialTests` + 29 Example tests green.
- [x] `xcodebuild -destination macOS` build succeeds.
- [x] `Bookshelf.app` launches and exits cleanly on macOS.
- [ ] Reviewer: run the app on macOS, open Settings → API, type a token, Save → footer reads "Saved"; quit + relaunch → still "Saved"; tap Clear → "Not set".
- [ ] Reviewer: same round-trip on iOS Simulator.