### PR TITLE
Fix silent-timeout in waitUntil test helper across all test files

### DIFF
--- a/Example/BookshelfTests/CatalogIntegrationTests.swift
+++ b/Example/BookshelfTests/CatalogIntegrationTests.swift
@@ -6,17 +6,6 @@ import Splint
 @MainActor
 @Suite("Bookshelf catalog integration")
 struct CatalogIntegrationTests {
-  private func waitUntil(
-    timeout: Duration = .seconds(2),
-    _ condition: () -> Bool
-  ) async {
-    let deadline = ContinuousClock.now.advanced(by: timeout)
-    while ContinuousClock.now < deadline {
-      if condition() { return }
-      try? await Task.sleep(for: .milliseconds(5))
-    }
-  }
-
   @Test func loadPopulatesCatalog() async {
     let client = BookClient.mock
     let catalog = Catalog<Book, BookCriteria>(fetch: client.fetchBooks)

--- a/Example/BookshelfTests/JobIntegrationTests.swift
+++ b/Example/BookshelfTests/JobIntegrationTests.swift
@@ -6,17 +6,6 @@ import Splint
 @MainActor
 @Suite("Bookshelf Job integration")
 struct JobIntegrationTests {
-  private func waitUntil(
-    timeout: Duration = .seconds(2),
-    _ condition: () -> Bool
-  ) async {
-    let deadline = ContinuousClock.now.advanced(by: timeout)
-    while ContinuousClock.now < deadline {
-      if condition() { return }
-      try? await Task.sleep(for: .milliseconds(5))
-    }
-  }
-
   @Test func fetchMetadataLifecycle() async {
     let job = Job<BookMetadata>()
     let client = BookClient.mock

--- a/Example/BookshelfTests/ViewLogicTests.swift
+++ b/Example/BookshelfTests/ViewLogicTests.swift
@@ -17,19 +17,6 @@ struct ViewLogicTests {
     return c
   }
 
-  private func waitUntil(
-    timeout: Duration = .seconds(2),
-    _ condition: () -> Bool,
-    sourceLocation: SourceLocation = #_sourceLocation
-  ) async {
-    let deadline = ContinuousClock.now.advanced(by: timeout)
-    while ContinuousClock.now < deadline {
-      if condition() { return }
-      try? await Task.sleep(for: .milliseconds(5))
-    }
-    #expect(condition(), "waitUntil timed out after \(timeout)", sourceLocation: sourceLocation)
-  }
-
   // MARK: - displayLens: combined search + genre filter
 
   @Test func displayLensFiltersBySearchAndGenreTogether() async {

--- a/Example/BookshelfTests/WaitUntil.swift
+++ b/Example/BookshelfTests/WaitUntil.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Testing
+
+/// Polls `condition` until it returns true or `timeout` elapses, yielding
+/// cooperatively between checks so `@MainActor` Task updates can land.
+/// On timeout, fails at the call site rather than returning silently.
+@MainActor
+func waitUntil(
+  timeout: Duration = .seconds(2),
+  _ condition: () -> Bool,
+  sourceLocation: SourceLocation = #_sourceLocation
+) async {
+  let deadline = ContinuousClock.now.advanced(by: timeout)
+  while ContinuousClock.now < deadline {
+    if condition() { return }
+    try? await Task.sleep(for: .milliseconds(5))
+  }
+  #expect(condition(), "waitUntil timed out after \(timeout)", sourceLocation: sourceLocation)
+}

--- a/Tests/SplintTests/CatalogTests.swift
+++ b/Tests/SplintTests/CatalogTests.swift
@@ -21,17 +21,6 @@ private struct Boom: Error, LocalizedError {
 @MainActor
 @Suite("Catalog")
 struct CatalogTests {
-  private func waitUntil(
-    timeout: Duration = .seconds(2),
-    _ condition: () -> Bool
-  ) async {
-    let deadline = ContinuousClock.now.advanced(by: timeout)
-    while ContinuousClock.now < deadline {
-      if condition() { return }
-      try? await Task.sleep(for: .milliseconds(5))
-    }
-  }
-
   private func makeCatalog(
     items: [TestItem] = [
       TestItem(id: 1, name: "A", score: 10),

--- a/Tests/SplintTests/GroupedLensLargeNTests.swift
+++ b/Tests/SplintTests/GroupedLensLargeNTests.swift
@@ -17,19 +17,6 @@ private final class LockCounter: @unchecked Sendable {
 struct GroupedLensLargeNTests {
   private let n = 1_000
 
-  private func waitUntil(
-    timeout: Duration = .seconds(2),
-    _ condition: () -> Bool,
-    sourceLocation: SourceLocation = #_sourceLocation
-  ) async {
-    let deadline = ContinuousClock.now.advanced(by: timeout)
-    while ContinuousClock.now < deadline {
-      if condition() { return }
-      try? await Task.sleep(for: .milliseconds(5))
-    }
-    #expect(condition(), "waitUntil timed out after \(timeout)", sourceLocation: sourceLocation)
-  }
-
   private func loadedCatalog(_ items: [TestItem]) async -> Catalog<TestItem, TestCriteria> {
     let c = Catalog<TestItem, TestCriteria> { _ in items }
     c.load(TestCriteria(category: "any"))

--- a/Tests/SplintTests/GroupedLensTests.swift
+++ b/Tests/SplintTests/GroupedLensTests.swift
@@ -21,19 +21,6 @@ private enum Priority: String, Hashable, Comparable, Sendable {
 @MainActor
 @Suite("GroupedLens")
 struct GroupedLensTests {
-  private func waitUntil(
-    timeout: Duration = .seconds(2),
-    _ condition: () -> Bool,
-    sourceLocation: SourceLocation = #_sourceLocation
-  ) async {
-    let deadline = ContinuousClock.now.advanced(by: timeout)
-    while ContinuousClock.now < deadline {
-      if condition() { return }
-      try? await Task.sleep(for: .milliseconds(5))
-    }
-    #expect(condition(), "waitUntil timed out after \(timeout)", sourceLocation: sourceLocation)
-  }
-
   private let sample: [TestItem] = [
     TestItem(id: 1, name: "banana", score: 5),
     TestItem(id: 2, name: "apple", score: 9),

--- a/Tests/SplintTests/JobTests.swift
+++ b/Tests/SplintTests/JobTests.swift
@@ -29,19 +29,6 @@ private final class FakeMainActorService {
 @MainActor
 @Suite("Job")
 struct JobTests {
-  /// Poll until `condition` returns true or timeout elapses. Yields
-  /// cooperatively so that @MainActor Task updates can land.
-  private func waitUntil(
-    timeout: Duration = .seconds(2),
-    _ condition: () -> Bool
-  ) async {
-    let deadline = ContinuousClock.now.advanced(by: timeout)
-    while ContinuousClock.now < deadline {
-      if condition() { return }
-      try? await Task.sleep(for: .milliseconds(5))
-    }
-  }
-
   @Test func runTransitionsPhaseIdleToCompleted() async {
     let job = Job<Int>()
     #expect(job.phase == .idle)

--- a/Tests/SplintTests/LensLargeNTests.swift
+++ b/Tests/SplintTests/LensLargeNTests.swift
@@ -19,17 +19,6 @@ private final class LockCounter: @unchecked Sendable {
 struct LensLargeNTests {
   private let n = 1_000
 
-  private func waitUntil(
-    timeout: Duration = .seconds(2),
-    _ condition: () -> Bool
-  ) async {
-    let deadline = ContinuousClock.now.advanced(by: timeout)
-    while ContinuousClock.now < deadline {
-      if condition() { return }
-      try? await Task.sleep(for: .milliseconds(5))
-    }
-  }
-
   private func loadedCatalog(_ items: [TestItem]) async -> Catalog<TestItem, TestCriteria> {
     let c = Catalog<TestItem, TestCriteria> { _ in items }
     c.load(TestCriteria(category: "any"))

--- a/Tests/SplintTests/LensTests.swift
+++ b/Tests/SplintTests/LensTests.swift
@@ -6,17 +6,6 @@ import Testing
 @MainActor
 @Suite("Lens")
 struct LensTests {
-  private func waitUntil(
-    timeout: Duration = .seconds(2),
-    _ condition: () -> Bool
-  ) async {
-    let deadline = ContinuousClock.now.advanced(by: timeout)
-    while ContinuousClock.now < deadline {
-      if condition() { return }
-      try? await Task.sleep(for: .milliseconds(5))
-    }
-  }
-
   private let sample: [TestItem] = [
     TestItem(id: 1, name: "banana", score: 5),
     TestItem(id: 2, name: "apple", score: 9),

--- a/Tests/SplintTests/WaitUntil.swift
+++ b/Tests/SplintTests/WaitUntil.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Testing
+
+/// Polls `condition` until it returns true or `timeout` elapses, yielding
+/// cooperatively between checks so `@MainActor` Task updates can land.
+/// On timeout, fails at the call site rather than returning silently.
+@MainActor
+func waitUntil(
+  timeout: Duration = .seconds(2),
+  _ condition: () -> Bool,
+  sourceLocation: SourceLocation = #_sourceLocation
+) async {
+  let deadline = ContinuousClock.now.advanced(by: timeout)
+  while ContinuousClock.now < deadline {
+    if condition() { return }
+    try? await Task.sleep(for: .milliseconds(5))
+  }
+  #expect(condition(), "waitUntil timed out after \(timeout)", sourceLocation: sourceLocation)
+}


### PR DESCRIPTION
## Summary

- Extracts the duplicated `waitUntil` polling helper into shared `WaitUntil.swift` files (one per test target) and removes the seven private copies that were drifting in the SplintTests and BookshelfTests targets.
- Fixes the underlying bug: when the deadline expired the helper returned silently with no assertion, letting tests proceed with incomplete setup and fail downstream for the wrong reasons. The shared helper now emits `#expect(condition(), ...)` on timeout, reporting the failure at the original call site via `#_sourceLocation`.
- Drive-by: collapses a `swift-format` `RemoveLine` violation in `Credential.swift` (preexisting on `main`, surfaced by `script/lint`).

## Why

The same helper was already fixed in three files as part of the GroupedLens work (commit `e018ed5`), with the rest flagged as a follow-up. This PR finishes that follow-up and consolidates the helper so the fix can't drift again.

## Test plan

- [x] `./script/test` — 85 SplintTests + 33 BookshelfTests pass.
- [x] `./script/lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)