### PR TITLE
Add GroupedLens sibling type for sectioned projections

### DIFF
--- a/Benchmarks/LensBenchmarks/LensBenchmarks.swift
+++ b/Benchmarks/LensBenchmarks/LensBenchmarks.swift
@@ -103,6 +103,51 @@ let benchmarks: @Sendable () -> Void = {
       lens.updateFilter { $0.score > n / 2 }
     }
   }
+
+  // GroupedLens: 32 buckets of ~31k items each — representative of a
+  // real sectioned-list cardinality (not "one group" or "one item per
+  // group"). Measures the grouping pass on top of filter+sort.
+  Benchmark(
+    "GroupedLens_1M_initFilterSortGrouping",
+    configuration: .init(
+      thresholds: [
+        .wallClock: .init(relative: [.p90: 50.0]),
+        .mallocCountTotal: .init(relative: [.p90: 25.0]),
+      ]
+    )
+  ) { benchmark in
+    let catalog = await primeCatalog(n: n)
+    benchmark.startMeasurement()
+    await MainActor.run {
+      blackHole(
+        GroupedLens<BenchItem, Int>(
+          source: catalog,
+          filter: { $0.score % 2 == 0 },
+          sort: { $0.score < $1.score },
+          categorize: { $0.score % 32 }
+        )
+      )
+    }
+  }
+
+  Benchmark(
+    "GroupedLens_1M_updateGrouping",
+    configuration: .init(
+      thresholds: [
+        .wallClock: .init(relative: [.p90: 50.0]),
+        .mallocCountTotal: .init(relative: [.p90: 25.0]),
+      ]
+    )
+  ) { benchmark in
+    let catalog = await primeCatalog(n: n)
+    let lens = await MainActor.run {
+      GroupedLens<BenchItem, Int>(source: catalog)
+    }
+    benchmark.startMeasurement()
+    await MainActor.run {
+      lens.updateCategories { $0.score % 32 }
+    }
+  }
 }
 
 // MARK: - Fixtures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `GroupedLens<Item, Category>` — a new sibling projection type
+  alongside `Lens<Item>` for sectioned lists. Exposes both the
+  filter+sort output (`items`) and a cached grouped form
+  (`groups: [(category: Category, items: [Item])]`) derived from an
+  optional `@Sendable (Item) -> Category` categorizer. Groups are
+  ordered by `Category`'s `Comparable`; items within each group
+  preserve the lens's sort. Enables `ForEach { Section }` SwiftUI
+  patterns without per-render `Dictionary(grouping:)`
+  ([#26](https://github.com/searlsco/splint/issues/26)).
+
 ## [0.1.0] - 2026-04-17
 
 ### Added

--- a/Example/Bookshelf/BookCatalog+Environment.swift
+++ b/Example/Bookshelf/BookCatalog+Environment.swift
@@ -8,8 +8,7 @@ import Splint
 
 extension EnvironmentValues {
   @Entry public var bookCatalog: Catalog<Book, BookCriteria>? = nil
-  @Entry public var searchLens: Lens<Book>? = nil
-  @Entry public var genreLens: Lens<Book>? = nil
+  @Entry public var displayLens: GroupedLens<Book, String>? = nil
   @Entry public var bookSelection: Selection<String>? = nil
   @Entry public var showCoversSetting: Setting<Bool>? = nil
   @Entry public var preferredGenreSetting: Setting<String>? = nil

--- a/Example/Bookshelf/BookClient.swift
+++ b/Example/Bookshelf/BookClient.swift
@@ -71,5 +71,15 @@ extension BookClient {
     Book(id: "3", title: "Refactoring", author: "Martin Fowler", genre: "Nonfiction", year: 1999),
     Book(id: "4", title: "Annihilation", author: "Jeff VanderMeer", genre: "Fiction", year: 2014),
     Book(id: "5", title: "The Design of Everyday Things", author: "Don Norman", genre: "Nonfiction", year: 1988),
+    Book(id: "6", title: "The Dark Forest", author: "Liu Cixin", genre: "Fiction", year: 2008),
+    Book(id: "7", title: "Death's End", author: "Liu Cixin", genre: "Fiction", year: 2010),
+    Book(id: "8", title: "Authority", author: "Jeff VanderMeer", genre: "Fiction", year: 2014),
+    Book(id: "9", title: "Acceptance", author: "Jeff VanderMeer", genre: "Fiction", year: 2014),
+    Book(id: "10", title: "Working Effectively with Legacy Code", author: "Michael Feathers", genre: "Nonfiction", year: 2004),
+    Book(id: "11", title: "Growing Object-Oriented Software", author: "Freeman & Pryce", genre: "Nonfiction", year: 2009),
+    Book(id: "12", title: "The Mythical Man-Month", author: "Fred Brooks", genre: "Nonfiction", year: 1975),
+    Book(id: "13", title: "A Memory Called Empire", author: "Arkady Martine", genre: "Fiction", year: 2019),
+    Book(id: "14", title: "A Desolation Called Peace", author: "Arkady Martine", genre: "Fiction", year: 2021),
+    Book(id: "15", title: "Piranesi", author: "Susanna Clarke", genre: "Fiction", year: 2020),
   ]
 }

--- a/Example/Bookshelf/BookListView.swift
+++ b/Example/Bookshelf/BookListView.swift
@@ -2,35 +2,36 @@ import SwiftData
 import SwiftUI
 import Splint
 
-/// Lists books at the intersection of two lenses on the same catalog —
-/// `searchLens` (title/author substring) and `genreLens` (preferred
-/// genre). The combination of `List(selection:)` + `NavigationLink(value:)`
-/// is Apple's canonical NavigationSplitView pattern: selection drives the
-/// detail column on regular widths, NavigationLink provides the push +
-/// chevron affordance on iPhone compact.
+/// Renders the Bookshelf list from a single ``GroupedLens``. When the
+/// toolbar grouping menu is set to `.none`, the body reads
+/// `displayLens.items` directly; when set to `.author` or `.genre`, it
+/// reads `displayLens.groups` and renders a sectioned `List`. The
+/// search query and preferred genre both compose into the same
+/// `updateFilter` call on the same lens — one list, one lens.
 public struct BookListView: View {
   @Environment(\.bookCatalog) private var catalog
-  @Environment(\.searchLens) private var searchLens
-  @Environment(\.genreLens) private var genreLens
+  @Environment(\.displayLens) private var displayLens
   @Environment(\.bookSelection) private var selection
   @Environment(\.showCoversSetting) private var showCovers
   @Query(sort: \Favorite.dateAdded) private var favorites: [Favorite]
 
-  @State private var query: String = ""
+  @Binding var query: String
+  @State private var grouping: Grouping = .none
 
-  public init() {}
-
-  private var visibleBooks: [Book] {
-    guard let searchLens, let genreLens else { return [] }
-    return Self.intersection(search: searchLens.items, genre: genreLens.items)
+  enum Grouping: String, CaseIterable, Identifiable {
+    case none, author, genre
+    var id: String { rawValue }
+    var label: String {
+      switch self {
+      case .none: "None"
+      case .author: "Author"
+      case .genre: "Genre"
+      }
+    }
   }
 
-  /// Intersection of two lens projections by `id`. Extracted for
-  /// testability — exercises the `Set`-based O(n) lookup and the
-  /// boundary cases (either lens empty).
-  static func intersection(search: [Book], genre: [Book]) -> [Book] {
-    let genreIDs = Set(genre.map(\.id))
-    return search.filter { genreIDs.contains($0.id) }
+  public init(query: Binding<String>) {
+    self._query = query
   }
 
   public var body: some View {
@@ -38,45 +39,76 @@ public struct BookListView: View {
       get: { selection?.current },
       set: { selection?.current = $0 }
     )) {
-      ForEach(visibleBooks) { book in
-        NavigationLink(value: book.id) {
-          BookRowView(
-            book: book,
-            isFavorite: favorites.contains { $0.bookID == book.id },
-            showCover: showCovers?.value ?? true
-          )
+      if grouping == .none {
+        ForEach(displayLens?.items ?? []) { book in
+          row(for: book)
+        }
+      } else {
+        ForEach(displayLens?.groups ?? [], id: \.category) { group in
+          Section(group.category) {
+            ForEach(group.items) { book in row(for: book) }
+          }
         }
       }
     }
-    .overlay {
-      if visibleBooks.isEmpty {
-        switch catalog?.phase {
-        case .idle, .running, nil:
-          ProgressView("Loading books…")
-        case .completed:
-          ContentUnavailableView(
-            "No Books",
-            systemImage: "books.vertical",
-            description: Text("Try a different search or genre.")
-          )
-        case .failed(let message):
-          ContentUnavailableView(
-            "Couldn't load books",
-            systemImage: "exclamationmark.triangle",
-            description: Text(message)
-          )
-        }
-      }
-    }
+    .overlay { emptyStateOverlay }
     .searchable(text: $query)
-    .onChange(of: query) { _, new in
-      let needle = new.lowercased()
-      searchLens?.updateFilter { book in
-        needle.isEmpty
-          || book.title.lowercased().contains(needle)
-          || book.author.lowercased().contains(needle)
+    .toolbar {
+      ToolbarItem {
+        Menu {
+          Picker("Group by", selection: $grouping) {
+            ForEach(Grouping.allCases) { option in
+              Text(option.label).tag(option)
+            }
+          }
+        } label: {
+          Label("Group by", systemImage: "square.stack.3d.up")
+        }
+        .accessibilityLabel("Group by")
       }
     }
+    .onChange(of: grouping) { _, new in applyGrouping(new) }
     .navigationTitle("Bookshelf")
+  }
+
+  private func row(for book: Book) -> some View {
+    NavigationLink(value: book.id) {
+      BookRowView(
+        book: book,
+        isFavorite: favorites.contains { $0.bookID == book.id },
+        showCover: showCovers?.value ?? true
+      )
+    }
+  }
+
+  @ViewBuilder
+  private var emptyStateOverlay: some View {
+    let items = displayLens?.items ?? []
+    if items.isEmpty {
+      switch catalog?.phase {
+      case .idle, .running, nil:
+        ProgressView("Loading books…")
+      case .completed:
+        ContentUnavailableView(
+          "No Books",
+          systemImage: "books.vertical",
+          description: Text("Try a different search or genre.")
+        )
+      case .failed(let message):
+        ContentUnavailableView(
+          "Couldn't load books",
+          systemImage: "exclamationmark.triangle",
+          description: Text(message)
+        )
+      }
+    }
+  }
+
+  private func applyGrouping(_ g: Grouping) {
+    switch g {
+    case .none: displayLens?.updateCategories(nil)
+    case .author: displayLens?.updateCategories { $0.author }
+    case .genre: displayLens?.updateCategories { $0.genre }
+    }
   }
 }

--- a/Example/Bookshelf/ContentView.swift
+++ b/Example/Bookshelf/ContentView.swift
@@ -4,16 +4,16 @@ import Splint
 
 /// The authenticated-root view. Owns every Splint instance as `@State`
 /// and distributes them via `.environment()`. Lifetime of the catalog
-/// and lenses is bound to this view — SwiftUI handles teardown.
+/// and lens is bound to this view — SwiftUI handles teardown.
 public struct ContentView: View {
   private let client: BookClient
 
   @State private var catalog: Catalog<Book, BookCriteria>
-  @State private var searchLens: Lens<Book>
-  @State private var genreLens: Lens<Book>
+  @State private var displayLens: GroupedLens<Book, String>
   @State private var selection = Selection<String>()
   @State private var showCovers = Setting<Bool>("showCovers", default: true)
   @State private var preferredGenre = Setting<String>("preferredGenre", default: "All")
+  @State private var query: String = ""
   @State private var apiCredentialStatus = CredentialStatus(
     credential: Credential(
       service: bookshelfCredentialService,
@@ -26,14 +26,13 @@ public struct ContentView: View {
     self.client = client
     let c = Catalog<Book, BookCriteria>(fetch: client.fetchBooks)
     self._catalog = State(initialValue: c)
-    self._searchLens = State(initialValue: Lens<Book>(source: c))
-    self._genreLens = State(initialValue: Lens<Book>(source: c))
+    self._displayLens = State(initialValue: GroupedLens<Book, String>(source: c))
   }
 
   public var body: some View {
     TabView {
       NavigationSplitView {
-        BookListView()
+        BookListView(query: $query)
       } detail: {
         if let id = selection.current, let book = catalog[id: id] {
           BookDetailView(book: book, client: client)
@@ -54,8 +53,7 @@ public struct ContentView: View {
       .tabItem { Label("Settings", systemImage: "gear") }
     }
     .environment(\.bookCatalog, catalog)
-    .environment(\.searchLens, searchLens)
-    .environment(\.genreLens, genreLens)
+    .environment(\.displayLens, displayLens)
     .environment(\.bookSelection, selection)
     .environment(\.showCoversSetting, showCovers)
     .environment(\.preferredGenreSetting, preferredGenre)
@@ -66,13 +64,23 @@ public struct ContentView: View {
     }
     // `initial: true` is load-bearing: `Setting` reads from UserDefaults
     // at init, so on any relaunch after the user picked a non-"All"
-    // genre the Picker reads e.g. "Fiction" but `genreLens` still has
-    // its default all-true filter. Firing onChange once on appear
-    // seeds the lens from the persisted Setting.
-    .onChange(of: preferredGenre.value, initial: true) { _, new in
-      genreLens.updateFilter { book in
-        new == "All" || book.genre == new
-      }
+    // genre the Picker reads e.g. "Fiction" but the lens still has its
+    // default all-true filter. Firing onChange once on appear seeds
+    // the lens from the persisted Setting.
+    .onChange(of: query, initial: true) { _, _ in applyFilter() }
+    .onChange(of: preferredGenre.value, initial: true) { _, _ in applyFilter() }
+  }
+
+  private func applyFilter() {
+    let needle = query.lowercased()
+    let genre = preferredGenre.value
+    displayLens.updateFilter { book in
+      let genreOK = genre == "All" || book.genre == genre
+      let searchOK =
+        needle.isEmpty
+        || book.title.lowercased().contains(needle)
+        || book.author.lowercased().contains(needle)
+      return genreOK && searchOK
     }
   }
 }

--- a/Example/BookshelfTests/ViewLogicTests.swift
+++ b/Example/BookshelfTests/ViewLogicTests.swift
@@ -64,6 +64,25 @@ struct ViewLogicTests {
     #expect(lens.groups.first { $0.category == "Lopez" }?.items.count == 2)
   }
 
+  @Test func groupingByGenreProducesOneGroupPerDistinctGenre() async {
+    let books = [
+      book("1", author: "A", genre: "Fiction"),
+      book("2", author: "B", genre: "Nonfiction"),
+      book("3", author: "C", genre: "Fiction"),
+      book("4", author: "D", genre: "Biography"),
+    ]
+    let catalog = Catalog<Book, BookCriteria> { _ in books }
+    catalog.load(BookCriteria(libraryID: "main"))
+    await waitUntil { catalog.phase == .completed }
+    let lens = GroupedLens<Book, String>(
+      source: catalog,
+      categorize: { $0.genre }
+    )
+    #expect(lens.groups.map(\.category) == ["Biography", "Fiction", "Nonfiction"])
+    #expect(lens.groups.first { $0.category == "Fiction" }?.items.map(\.id).sorted() == ["1", "3"])
+    #expect(lens.groups.first { $0.category == "Biography" }?.items.map(\.id) == ["4"])
+  }
+
   @Test func groupingNoneLeavesGroupsEmpty() async {
     let books = [book("1", genre: "X")]
     let catalog = Catalog<Book, BookCriteria> { _ in books }

--- a/Example/BookshelfTests/ViewLogicTests.swift
+++ b/Example/BookshelfTests/ViewLogicTests.swift
@@ -12,13 +12,15 @@ struct ViewLogicTests {
 
   private func waitUntil(
     timeout: Duration = .seconds(2),
-    _ condition: () -> Bool
+    _ condition: () -> Bool,
+    sourceLocation: SourceLocation = #_sourceLocation
   ) async {
     let deadline = ContinuousClock.now.advanced(by: timeout)
     while ContinuousClock.now < deadline {
       if condition() { return }
       try? await Task.sleep(for: .milliseconds(5))
     }
+    #expect(condition(), "waitUntil timed out after \(timeout)", sourceLocation: sourceLocation)
   }
 
   // MARK: - displayLens: combined search + genre filter

--- a/Example/BookshelfTests/ViewLogicTests.swift
+++ b/Example/BookshelfTests/ViewLogicTests.swift
@@ -10,6 +10,13 @@ struct ViewLogicTests {
     Book(id: id, title: title, author: author, genre: genre, year: 2020)
   }
 
+  private func loadedBookCatalog(_ books: [Book]) async -> Catalog<Book, BookCriteria> {
+    let c = Catalog<Book, BookCriteria> { _ in books }
+    c.load(BookCriteria(libraryID: "main"))
+    await waitUntil { c.phase == .completed }
+    return c
+  }
+
   private func waitUntil(
     timeout: Duration = .seconds(2),
     _ condition: () -> Bool,
@@ -83,34 +90,41 @@ struct ViewLogicTests {
     #expect(lens.groups.first { $0.category == "Biography" }?.items.map(\.id) == ["4"])
   }
 
-  @Test func groupingNoneLeavesGroupsEmpty() async {
-    let books = [book("1", genre: "X")]
-    let catalog = Catalog<Book, BookCriteria> { _ in books }
-    catalog.load(BookCriteria(libraryID: "main"))
-    await waitUntil { catalog.phase == .completed }
+  @Test func groupingNilCategorizeLeavesGroupsEmpty() async {
+    let catalog = await loadedBookCatalog([book("1", genre: "X")])
     let lens = GroupedLens<Book, String>(source: catalog)
     #expect(lens.groups.isEmpty)
+  }
+
+  @Test func groupingNilCategorizeStillPopulatesItems() async {
+    let catalog = await loadedBookCatalog([book("1", genre: "X")])
+    let lens = GroupedLens<Book, String>(source: catalog)
     #expect(lens.items.count == 1)
   }
 
-  @Test func togglingGroupingKeepsItemsStable() async {
-    let books = [
+  @Test func enablingGroupingPreservesItems() async {
+    let catalog = await loadedBookCatalog([
       book("1", author: "A", genre: "X"),
       book("2", author: "B", genre: "Y"),
-    ]
-    let catalog = Catalog<Book, BookCriteria> { _ in books }
-    catalog.load(BookCriteria(libraryID: "main"))
-    await waitUntil { catalog.phase == .completed }
+    ])
     let lens = GroupedLens<Book, String>(source: catalog)
-    let idsBeforeGrouping = lens.items.map(\.id)
-
+    let idsBefore = lens.items.map(\.id)
     lens.updateCategories { $0.author }
-    #expect(!lens.groups.isEmpty)
-    #expect(lens.items.map(\.id) == idsBeforeGrouping)
+    #expect(lens.items.map(\.id) == idsBefore)
+  }
 
+  @Test func disablingGroupingPreservesItems() async {
+    let catalog = await loadedBookCatalog([
+      book("1", author: "A", genre: "X"),
+      book("2", author: "B", genre: "Y"),
+    ])
+    let lens = GroupedLens<Book, String>(
+      source: catalog,
+      categorize: { $0.author }
+    )
+    let idsBefore = lens.items.map(\.id)
     lens.updateCategories(nil)
-    #expect(lens.groups.isEmpty)
-    #expect(lens.items.map(\.id) == idsBeforeGrouping)
+    #expect(lens.items.map(\.id) == idsBefore)
   }
 
   // MARK: - genres clamp

--- a/Example/BookshelfTests/ViewLogicTests.swift
+++ b/Example/BookshelfTests/ViewLogicTests.swift
@@ -6,8 +6,8 @@ import Splint
 @MainActor
 @Suite("Bookshelf view-logic composition")
 struct ViewLogicTests {
-  private func book(_ id: String, genre: String) -> Book {
-    Book(id: id, title: "T\(id)", author: "A", genre: genre, year: 2020)
+  private func book(_ id: String, title: String = "T", author: String = "A", genre: String) -> Book {
+    Book(id: id, title: title, author: author, genre: genre, year: 2020)
   }
 
   private func waitUntil(
@@ -21,36 +21,75 @@ struct ViewLogicTests {
     }
   }
 
-  // MARK: - visibleBooks intersection
+  // MARK: - displayLens: combined search + genre filter
 
-  @Test func intersectionKeepsOnlyBooksInBothLenses() {
-    let f = book("f", genre: "Fiction")
-    let n = book("n", genre: "Nonfiction")
-    #expect(
-      BookListView.intersection(search: [f, n], genre: [f]).map(\.id) == ["f"]
+  @Test func displayLensFiltersBySearchAndGenreTogether() async {
+    let books = [
+      book("1", title: "Pragmatic Programmer", genre: "Nonfiction"),
+      book("2", title: "Annihilation", genre: "Fiction"),
+      book("3", title: "Authority", genre: "Fiction"),
+    ]
+    let catalog = Catalog<Book, BookCriteria> { _ in books }
+    catalog.load(BookCriteria(libraryID: "main"))
+    await waitUntil { catalog.phase == .completed }
+    let lens = GroupedLens<Book, String>(source: catalog)
+
+    // Composite filter matches what ContentView.applyFilter installs.
+    lens.updateFilter { b in
+      b.genre == "Fiction" && b.title.lowercased().contains("author")
+    }
+
+    #expect(lens.items.map(\.id) == ["3"])
+  }
+
+  // MARK: - grouping via displayLens
+
+  @Test func groupingByAuthorProducesOneGroupPerDistinctAuthor() async {
+    let books = [
+      book("1", author: "Lopez", genre: "X"),
+      book("2", author: "Carr", genre: "X"),
+      book("3", author: "Lopez", genre: "X"),
+      book("4", author: "Abrams", genre: "X"),
+    ]
+    let catalog = Catalog<Book, BookCriteria> { _ in books }
+    catalog.load(BookCriteria(libraryID: "main"))
+    await waitUntil { catalog.phase == .completed }
+    let lens = GroupedLens<Book, String>(
+      source: catalog,
+      categorize: { $0.author }
     )
+    #expect(lens.groups.map(\.category) == ["Abrams", "Carr", "Lopez"])
+    #expect(lens.groups.first { $0.category == "Lopez" }?.items.count == 2)
   }
 
-  @Test func intersectionWhenGenreLensIsEmpty() {
-    let a = book("a", genre: "X")
-    #expect(BookListView.intersection(search: [a], genre: []).isEmpty)
+  @Test func groupingNoneLeavesGroupsEmpty() async {
+    let books = [book("1", genre: "X")]
+    let catalog = Catalog<Book, BookCriteria> { _ in books }
+    catalog.load(BookCriteria(libraryID: "main"))
+    await waitUntil { catalog.phase == .completed }
+    let lens = GroupedLens<Book, String>(source: catalog)
+    #expect(lens.groups.isEmpty)
+    #expect(lens.items.count == 1)
   }
 
-  @Test func intersectionWhenSearchLensIsEmpty() {
-    let a = book("a", genre: "X")
-    #expect(BookListView.intersection(search: [], genre: [a]).isEmpty)
-  }
+  @Test func togglingGroupingKeepsItemsStable() async {
+    let books = [
+      book("1", author: "A", genre: "X"),
+      book("2", author: "B", genre: "Y"),
+    ]
+    let catalog = Catalog<Book, BookCriteria> { _ in books }
+    catalog.load(BookCriteria(libraryID: "main"))
+    await waitUntil { catalog.phase == .completed }
+    let lens = GroupedLens<Book, String>(source: catalog)
+    let idsBeforeGrouping = lens.items.map(\.id)
 
-  @Test func intersectionWhenBothLensesAreEmpty() {
-    #expect(BookListView.intersection(search: [], genre: []).isEmpty)
-  }
+    lens.updateCategories { $0.author }
+    #expect(!lens.groups.isEmpty)
+    #expect(lens.items.map(\.id) == idsBeforeGrouping)
 
-  @Test func intersectionPreservesSearchLensOrder() {
-    let a = book("a", genre: "X")
-    let b = book("b", genre: "X")
-    let c = book("c", genre: "X")
-    let result = BookListView.intersection(search: [c, a, b], genre: [a, b, c])
-    #expect(result.map(\.id) == ["c", "a", "b"])
+    lens.updateCategories(nil)
+    #expect(lens.groups.isEmpty)
+    #expect(lens.items.map(\.id) == idsBeforeGrouping)
   }
 
   // MARK: - genres clamp
@@ -97,9 +136,6 @@ struct ViewLogicTests {
     defer { store.removePersistentDomain(forName: suite) }
     store.set("Fiction", forKey: "preferredGenre")
 
-    // Simulate what ContentView does with `.onChange(initial: true)`:
-    // read the Setting's current value (now "Fiction" from UserDefaults)
-    // and apply it to the lens as the initial filter.
     let setting = Setting<String>("preferredGenre", default: "All", store: store)
     #expect(setting.value == "Fiction")
 
@@ -107,7 +143,7 @@ struct ViewLogicTests {
     catalog.load(BookCriteria(libraryID: "main"))
     await waitUntil { catalog.phase == .completed }
 
-    let lens = Lens<Book>(source: catalog)
+    let lens = GroupedLens<Book, String>(source: catalog)
     let current = setting.value
     lens.updateFilter { book in current == "All" || book.genre == current }
 
@@ -119,7 +155,6 @@ struct ViewLogicTests {
     let suite = "BookshelfTests.ViewLogicTests.\(UUID().uuidString)"
     let store = UserDefaults(suiteName: suite)!
     defer { store.removePersistentDomain(forName: suite) }
-    // No value set → Setting falls back to default "All".
     let setting = Setting<String>("preferredGenre", default: "All", store: store)
     #expect(setting.value == "All")
 
@@ -127,7 +162,7 @@ struct ViewLogicTests {
     catalog.load(BookCriteria(libraryID: "main"))
     await waitUntil { catalog.phase == .completed }
 
-    let lens = Lens<Book>(source: catalog)
+    let lens = GroupedLens<Book, String>(source: catalog)
     let current = setting.value
     lens.updateFilter { book in current == "All" || book.genre == current }
 

--- a/Example/README.md
+++ b/Example/README.md
@@ -31,7 +31,7 @@ source files — there's no duplication.
 |------|-------|
 | `Resource` | `Book` — immutable value, decoded (in this example: fixtures) |
 | `Catalog<Book, BookCriteria>` | Owned by `ContentView` via `@State`, distributed via `.environment()` |
-| `Lens<Book>` | `searchLens` (title/author substring) and `genreLens` (by preferred genre) |
+| `GroupedLens<Book, String>` | `displayLens` — composite filter (search + preferred genre) with optional grouping by author or genre |
 | `Job<BookMetadata>` | `@State` in `BookDetailView` — fetches extended metadata on demand |
 | `Selection<String>` | Active book id, bound to `List(selection:)` |
 | `Setting<Bool>` | `"showCovers"` toggle |

--- a/Sources/Splint/Credential.swift
+++ b/Sources/Splint/Credential.swift
@@ -146,8 +146,7 @@ public struct SystemKeychainBackend: CredentialBackend {
     return SecItemAdd(query as CFDictionary, nil)
   }
 
-  public func update(service: String, account: String, synchronizable: Bool, data: Data) -> OSStatus
-  {
+  public func update(service: String, account: String, synchronizable: Bool, data: Data) -> OSStatus {
     let query = baseQuery(service: service, account: account, synchronizable: synchronizable)
     let attrs: [String: Any] = [kSecValueData as String: data]
     return SecItemUpdate(query as CFDictionary, attrs as CFDictionary)

--- a/Sources/Splint/GroupedLens.swift
+++ b/Sources/Splint/GroupedLens.swift
@@ -1,4 +1,3 @@
-import Foundation
 import Observation
 
 /// A derived, read-only 2-D projection over a ``Catalog``. A

--- a/Sources/Splint/GroupedLens.swift
+++ b/Sources/Splint/GroupedLens.swift
@@ -1,0 +1,120 @@
+import Foundation
+import Observation
+
+/// A derived, read-only 2-D projection over a ``Catalog``. A
+/// `GroupedLens` watches its source's `items` and recomputes a
+/// filtered, sorted, and optionally grouped projection when the source
+/// changes or when any of the predicates change.
+///
+/// When the categorizer is `nil`, ``groups`` is empty and ``items``
+/// behaves identically to a plain ``Lens``. When non-nil, ``groups``
+/// exposes `[(category, items)]` pairs ordered by `Category`'s
+/// `Comparable` conformance; items within each group preserve the
+/// lens's sort order.
+///
+/// The source catalog's `Criteria` type is erased at init: call sites
+/// see `GroupedLens<Item, Category>`, not `GroupedLens<Item, Category,
+/// Criteria>`.
+///
+/// **Performance.** `recompute()` is O(n) for the filter pass, O(n log
+/// n) for the sort (stdlib introsort) when one is set, and O(n + k log
+/// k) for the grouping pass (k = distinct categories) when a
+/// categorizer is set. Under ~1k items this is negligible; for larger
+/// datasets, prefer server-side filtering via the catalog's `Criteria`
+/// over a client-side `GroupedLens`.
+@Observable
+@MainActor
+public final class GroupedLens<
+  Item: Resource,
+  Category: Hashable & Comparable & Sendable
+> {
+  /// The filtered and sorted projection of the source. Always
+  /// populated, regardless of whether a categorizer is set.
+  public private(set) var items: [Item] = []
+
+  /// The grouped projection, ordered by `Category`'s `Comparable`.
+  /// Empty when ``updateCategories(_:)`` has not been called or was
+  /// last called with `nil`.
+  public private(set) var groups: [(category: Category, items: [Item])] = []
+
+  @ObservationIgnored private let sourceItems: @MainActor () -> [Item]
+  @ObservationIgnored private var filter: @Sendable (Item) -> Bool
+  @ObservationIgnored private var order: (@Sendable (Item, Item) -> Bool)?
+  @ObservationIgnored private var categorize: (@Sendable (Item) -> Category)?
+
+  public init<Criteria: Equatable & Sendable>(
+    source: Catalog<Item, Criteria>,
+    /// Predicate applied to each item. Captured once at init; re-runs
+    /// only when `updateFilter` is called. Do not capture mutable view
+    /// state — drive `updateFilter` from `.onChange(of:)` instead.
+    filter: @escaping @Sendable (Item) -> Bool = { _ in true },
+    /// Comparator applied after filtering. Same capture rules as
+    /// `filter`.
+    sort: (@Sendable (Item, Item) -> Bool)? = nil,
+    /// Categorizer applied after sorting. When non-nil, ``groups`` is
+    /// populated with one entry per distinct `Category`, ordered by
+    /// `Category.<`. Items within each group preserve the lens's sort
+    /// order. Pass `nil` (or omit) to leave ``groups`` empty. Same
+    /// capture rules as `filter`.
+    categorize: (@Sendable (Item) -> Category)? = nil
+  ) {
+    self.sourceItems = { source.items }
+    self.filter = filter
+    self.order = sort
+    self.categorize = categorize
+    recompute()
+    observe()
+  }
+
+  /// Replace the filter predicate and recompute.
+  public func updateFilter(_ filter: @escaping @Sendable (Item) -> Bool) {
+    self.filter = filter
+    recompute()
+  }
+
+  /// Replace the sort predicate and recompute. Pass `nil` to remove
+  /// sorting and return to source order.
+  public func updateSort(_ sort: (@Sendable (Item, Item) -> Bool)?) {
+    self.order = sort
+    recompute()
+  }
+
+  /// Replace the categorizer and recompute. Pass `nil` to clear
+  /// ``groups`` back to empty without losing ``items``.
+  public func updateCategories(_ categorize: (@Sendable (Item) -> Category)?) {
+    self.categorize = categorize
+    recompute()
+  }
+
+  private func recompute() {
+    var result = sourceItems().filter(self.filter)
+    if let order { result.sort(by: order) }
+    items = result
+
+    guard let categorize else {
+      groups = []
+      return
+    }
+    var buckets: [Category: [Item]] = [:]
+    for item in result {
+      buckets[categorize(item), default: []].append(item)
+    }
+    groups = buckets.keys.sorted().map { key in
+      (category: key, items: buckets[key]!)
+    }
+  }
+
+  private func observe() {
+    // Re-arm tracking on every change. onChange fires *before* the mutation
+    // is committed, so defer the recompute to the next MainActor hop.
+    withObservationTracking { [weak self] in
+      _ = self?.sourceItems()
+    } onChange: { [weak self] in
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        self.recompute()
+        self.observe()
+      }
+    }
+  }
+}

--- a/Sources/Splint/Splint.docc/ChoosingTheRightType.md
+++ b/Sources/Splint/Splint.docc/ChoosingTheRightType.md
@@ -16,7 +16,8 @@ into `@State`, `@Environment`, `@Query`, and `@Observable`.
 |------|---------------|-------------|-------------|------------|
 | ``Resource`` | Decoded remote data | None — value type | None | Immutable after decode |
 | ``Catalog`` | Ordered collection of Resources loaded by criteria, plus fetch lifecycle | `@Observable` | None (in-memory cache) | Collection mutates on load/refresh |
-| ``Lens`` | Filtered/sorted/grouped view over a ``Catalog`` | `@Observable` | None | Criteria mutate; data is derived |
+| ``Lens`` | Filtered/sorted view over a ``Catalog`` | `@Observable` | None | Predicates mutate; data is derived |
+| ``GroupedLens`` | Filtered/sorted view + cached grouped sections | `@Observable` | None | Predicates mutate; data is derived |
 | ``Job`` | Async operation lifecycle | `@Observable` | None | Phase mutates as work progresses |
 | ``Selection`` | Currently selected item identifier | `@Observable` | None | Mutates on user tap |
 | ``Setting`` | Single typed user preference | `@Observable` | UserDefaults | Mutates, persists automatically |
@@ -27,6 +28,7 @@ into `@State`, `@Environment`, `@Query`, and `@Observable`.
 - Decoded remote data → ``Resource``
 - Collection of Resources → ``Catalog``
 - Filtered/sorted view of a Catalog → ``Lens``
+- Sectioned view of a Catalog → ``GroupedLens``
 - Async fetch lifecycle → ``Job``
 - Selected item identifier → ``Selection``
 - User preference → ``Setting``

--- a/Sources/Splint/Splint.docc/GroupedLensGuide.md
+++ b/Sources/Splint/Splint.docc/GroupedLensGuide.md
@@ -1,0 +1,136 @@
+# Grouped lenses for sectioned lists
+
+A ``GroupedLens`` is a derived, read-only 2-D projection over a
+``Catalog``: filter + sort + grouping, kept in sync automatically. Use
+it when you render sectioned content — `ForEach { Section }`.
+
+## Overview
+
+``Lens`` gives you a filtered, sorted flat array. ``GroupedLens``
+gives you the same `items` *plus* a cached `groups` property shaped as
+`[(category: Category, items: [Item])]`, produced by a caller-supplied
+`(Item) -> Category` closure. Groups are ordered by `Category`'s
+`Comparable` conformance; items within each group preserve the lens's
+sort order.
+
+The source catalog's `Criteria` type is erased at init: call sites see
+`GroupedLens<Book, String>`, not `GroupedLens<Book, BookCriteria,
+String>`.
+
+## Usage
+
+```swift
+let lens = GroupedLens<Book, String>(
+  source: catalog,
+  sort: { $0.title < $1.title },
+  categorize: { $0.author })
+
+// In the view:
+List {
+  ForEach(lens.groups, id: \.category) { group in
+    Section(group.category) {
+      ForEach(group.items) { BookRow(book: $0) }
+    }
+  }
+}
+```
+
+Compare with the inline-grouping anti-pattern that recomputes the
+dictionary on every body evaluation:
+
+```swift
+// ❌ O(n) allocation + dictionary build + sort on every render
+var body: some View {
+  let groups = Dictionary(grouping: lens.items, by: \.author)
+    .map { (author: $0.key, books: $0.value) }
+    .sorted { $0.author < $1.author }
+  List { … }
+}
+```
+
+``GroupedLens`` moves that work out of the render path: it happens
+once per source change or predicate update, not once per body
+evaluation.
+
+## Toggling grouping on and off
+
+Pass `nil` to ``GroupedLens/updateCategories(_:)`` to clear the
+categorizer. `items` stays populated (same filter + sort as before);
+`groups` becomes empty. Views can read `items` in their flat-list path
+and `groups` in their sectioned path:
+
+```swift
+if grouping == .none {
+  ForEach(lens.items) { … }
+} else {
+  ForEach(lens.groups, id: \.category) { group in
+    Section(group.category) { ForEach(group.items) { … } }
+  }
+}
+```
+
+This is the same lens instance either way — toggling is just a
+predicate swap, not a rebuild.
+
+## Group order
+
+Groups are always ordered by `Category`'s `Comparable`. If your
+category key is a `String`, that's lexicographic. If it's a custom
+type (an enum, an `Int`, a wrapper), define `<` to match the order you
+want section headers to appear in.
+
+Items within a group inherit the lens's `sort` — one sort rule covers
+both the flat list and every section.
+
+## Performance
+
+`recompute()` is O(n) for filter, O(n log n) for sort, and O(n + k
+log k) for grouping (k = distinct categories). One pass per source
+change or predicate update. Under ~1k items all three are negligible.
+For larger datasets, consider whether filtering belongs in the fetch
+closure (server-side via the catalog's `Criteria`) rather than in a
+client-side lens.
+
+## Closures capture once
+
+``GroupedLens`` captures `filter`, `sort`, and `categorize` at init.
+They re-run only on ``GroupedLens/updateFilter(_:)``,
+``GroupedLens/updateSort(_:)``, and
+``GroupedLens/updateCategories(_:)`` — not when variables they
+reference change. Capturing mutable view state at init compiles and
+looks correct, and fails silently:
+
+```swift
+// ❌ `grouping` capture goes stale
+@State private var grouping = Grouping.author
+@State private var lens = GroupedLens(
+  source: catalog,
+  categorize: { grouping == .author ? $0.author : $0.genre })
+
+// ✅ Drive updates explicitly
+@State private var grouping = Grouping.author
+@State private var lens = GroupedLens<Book, String>(source: catalog)
+
+var body: some View {
+  BookList(lens: lens)
+    .onChange(of: grouping) { _, new in
+      lens.updateCategories { book in
+        new == .author ? book.author : book.genre
+      }
+    }
+}
+```
+
+Same rule as ``Catalog``'s fetch closure and ``Lens``'s predicates:
+Splint closures capture at construction; mutable inputs flow through
+update methods.
+
+## Topics
+
+### Related
+
+- ``Catalog``
+- ``Lens``
+- ``Resource``
+- <doc:LensGuide>
+- <doc:ObservationBoundaries>

--- a/Sources/Splint/Splint.docc/LensGuide.md
+++ b/Sources/Splint/Splint.docc/LensGuide.md
@@ -55,10 +55,19 @@ var body: some View {
 Same rule as ``Catalog``'s fetch closure: Splint closures capture at
 construction; mutable inputs flow through update methods.
 
+## See also
+
+For sectioned `List` / `ForEach { Section }` rendering, use
+``GroupedLens`` — it adds a cached `groups` projection on top of the
+same filter + sort so you can render groups without recomputing
+`Dictionary(grouping:)` on every view body evaluation.
+
 ## Topics
 
 ### Related
 
 - ``Catalog``
+- ``GroupedLens``
 - ``Resource``
+- <doc:GroupedLensGuide>
 - <doc:ObservationBoundaries>

--- a/Sources/Splint/Splint.docc/Splint.md
+++ b/Sources/Splint/Splint.docc/Splint.md
@@ -15,6 +15,7 @@ Splint names them:
 - ``Resource`` — decoded remote data (channels, books, EPG entries)
 - ``Catalog`` — an ordered collection of Resources loaded by criteria
 - ``Lens`` — a filtered/sorted view over a Catalog
+- ``GroupedLens`` — a filtered/sorted view + cached grouped sections
 - ``Job`` — an async operation lifecycle
 - ``Selection`` — the currently selected item identifier
 - ``Setting`` — a single typed user preference (UserDefaults-backed)
@@ -43,6 +44,8 @@ observation. Pass model instances directly to child views.
 
 - <doc:LensGuide>
 - ``Lens``
+- <doc:GroupedLensGuide>
+- ``GroupedLens``
 
 ### Async operation lifecycle
 

--- a/Tests/SplintTests/GroupedLensLargeNTests.swift
+++ b/Tests/SplintTests/GroupedLensLargeNTests.swift
@@ -57,10 +57,12 @@ struct GroupedLensLargeNTests {
     }
   }
 
-  // Composition invariant: `recompute()` must invoke the categorizer
+  // Composition invariants: `recompute()` must invoke the categorizer
   // exactly once per item that passes the filter, per call. Guards a
-  // refactor that accidentally double-categorizes.
-  @Test func recomputeInvokesCategorizeExactlyOncePerFilteredItem() async {
+  // refactor that accidentally double-categorizes. Split by trigger so
+  // a failure identifies *which* recompute over-categorized.
+
+  @Test func initRecomputeInvokesCategorizeOncePerFilteredItem() async {
     let c = await loadedCatalog(makeItems(n))
     let counter = LockCounter()
 
@@ -72,11 +74,25 @@ struct GroupedLensLargeNTests {
         return item.score % 10
       }
     )
-    #expect(l.items.count == 500)
+    _ = l  // keep observation alive
     #expect(counter.value == 500, "init's recompute must invoke categorize exactly once per filtered item")
+  }
 
+  @Test func updateSortRecomputeInvokesCategorizeOncePerFilteredItem() async {
+    let c = await loadedCatalog(makeItems(n))
+    let counter = LockCounter()
+
+    let l = GroupedLens<TestItem, Int>(
+      source: c,
+      filter: { $0.score >= 500 },
+      categorize: { item in
+        counter.increment()
+        return item.score % 10
+      }
+    )
+    let afterInit = counter.value
     l.updateSort { $0.score < $1.score }
-    #expect(counter.value == 1_000, "updateSort's recompute must invoke categorize exactly 500 more times, not 1_000")
+    #expect(counter.value - afterInit == 500, "updateSort's recompute must invoke categorize exactly once per filtered item, not 2×")
   }
 
   @Test func groupingDoesNotDegradeSortStability() async {

--- a/Tests/SplintTests/GroupedLensLargeNTests.swift
+++ b/Tests/SplintTests/GroupedLensLargeNTests.swift
@@ -19,13 +19,15 @@ struct GroupedLensLargeNTests {
 
   private func waitUntil(
     timeout: Duration = .seconds(2),
-    _ condition: () -> Bool
+    _ condition: () -> Bool,
+    sourceLocation: SourceLocation = #_sourceLocation
   ) async {
     let deadline = ContinuousClock.now.advanced(by: timeout)
     while ContinuousClock.now < deadline {
       if condition() { return }
       try? await Task.sleep(for: .milliseconds(5))
     }
+    #expect(condition(), "waitUntil timed out after \(timeout)", sourceLocation: sourceLocation)
   }
 
   private func loadedCatalog(_ items: [TestItem]) async -> Catalog<TestItem, TestCriteria> {

--- a/Tests/SplintTests/GroupedLensLargeNTests.swift
+++ b/Tests/SplintTests/GroupedLensLargeNTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+
+@testable import Splint
+
+// Shared with LensLargeNTests; duplicated here until a third site earns
+// the extraction.
+private final class LockCounter: @unchecked Sendable {
+  private let lock = NSLock()
+  private var _value: Int = 0
+  func increment() { lock.withLock { _value += 1 } }
+  var value: Int { lock.withLock { _value } }
+}
+
+@MainActor
+@Suite("GroupedLensLargeN")
+struct GroupedLensLargeNTests {
+  private let n = 1_000
+
+  private func waitUntil(
+    timeout: Duration = .seconds(2),
+    _ condition: () -> Bool
+  ) async {
+    let deadline = ContinuousClock.now.advanced(by: timeout)
+    while ContinuousClock.now < deadline {
+      if condition() { return }
+      try? await Task.sleep(for: .milliseconds(5))
+    }
+  }
+
+  private func loadedCatalog(_ items: [TestItem]) async -> Catalog<TestItem, TestCriteria> {
+    let c = Catalog<TestItem, TestCriteria> { _ in items }
+    c.load(TestCriteria(category: "any"))
+    await waitUntil { c.phase == .completed }
+    return c
+  }
+
+  private func makeItems(_ count: Int) -> [TestItem] {
+    (0..<count).map { id in
+      TestItem(id: id, name: "item-\(id)", score: id)
+    }
+  }
+
+  @Test func groupsCorrectlyAtScale() async {
+    let c = await loadedCatalog(makeItems(n))
+    let l = GroupedLens<TestItem, Int>(
+      source: c,
+      categorize: { $0.score % 10 }
+    )
+    #expect(l.groups.count == 10)
+    #expect(l.groups.map(\.category) == Array(0..<10))
+    for (i, group) in l.groups.enumerated() {
+      #expect(group.items.count == n / 10, "bucket \(i) size")
+      #expect(group.items.allSatisfy { $0.score % 10 == i })
+    }
+  }
+
+  // Composition invariant: `recompute()` must invoke the categorizer
+  // exactly once per item that passes the filter, per call. Guards a
+  // refactor that accidentally double-categorizes.
+  @Test func recomputeInvokesCategorizeExactlyOncePerFilteredItem() async {
+    let c = await loadedCatalog(makeItems(n))
+    let counter = LockCounter()
+
+    let l = GroupedLens<TestItem, Int>(
+      source: c,
+      filter: { $0.score >= 500 },  // passes ids 500..999 → 500 items
+      categorize: { item in
+        counter.increment()
+        return item.score % 10
+      }
+    )
+    #expect(l.items.count == 500)
+    #expect(counter.value == 500, "init's recompute must invoke categorize exactly once per filtered item")
+
+    l.updateSort { $0.score < $1.score }
+    #expect(counter.value == 1_000, "updateSort's recompute must invoke categorize exactly 500 more times, not 1_000")
+  }
+
+  @Test func groupingDoesNotDegradeSortStability() async {
+    // Within a group, items should appear in the lens's sort order.
+    // Here: ascending by id (the default when no sort, since Catalog
+    // preserves source order and we build items in id-order).
+    let c = await loadedCatalog(makeItems(n))
+    let l = GroupedLens<TestItem, Int>(
+      source: c,
+      categorize: { $0.score % 10 }
+    )
+    for group in l.groups {
+      let ids = group.items.map(\.id)
+      #expect(ids == ids.sorted(), "group \(group.category): items must preserve source order")
+    }
+  }
+}

--- a/Tests/SplintTests/GroupedLensTests.swift
+++ b/Tests/SplintTests/GroupedLensTests.swift
@@ -1,0 +1,209 @@
+import Foundation
+import Testing
+
+@testable import Splint
+
+// A category type whose Comparable order is deliberately NOT alphabetic,
+// so tests that verify "groups are sorted by Category.<" can't pass by
+// coincidence with string ordering.
+private enum Priority: String, Hashable, Comparable, Sendable {
+  case high, medium, low
+  private var rank: Int {
+    switch self {
+    case .high: 0
+    case .medium: 1
+    case .low: 2
+    }
+  }
+  static func < (lhs: Priority, rhs: Priority) -> Bool { lhs.rank < rhs.rank }
+}
+
+@MainActor
+@Suite("GroupedLens")
+struct GroupedLensTests {
+  private func waitUntil(
+    timeout: Duration = .seconds(2),
+    _ condition: () -> Bool
+  ) async {
+    let deadline = ContinuousClock.now.advanced(by: timeout)
+    while ContinuousClock.now < deadline {
+      if condition() { return }
+      try? await Task.sleep(for: .milliseconds(5))
+    }
+  }
+
+  private let sample: [TestItem] = [
+    TestItem(id: 1, name: "banana", score: 5),
+    TestItem(id: 2, name: "apple", score: 9),
+    TestItem(id: 3, name: "cherry", score: 1),
+    TestItem(id: 4, name: "apricot", score: 7),
+  ]
+
+  private func loadedCatalog(_ items: [TestItem]) async -> Catalog<TestItem, TestCriteria> {
+    let c = Catalog<TestItem, TestCriteria> { _ in items }
+    c.load(TestCriteria(category: "any"))
+    await waitUntil { c.phase == .completed }
+    return c
+  }
+
+  @Test func itemsMirrorLensWhenCategorizeNil() async {
+    let c = await loadedCatalog(sample)
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      filter: { $0.score >= 5 },
+      sort: { $0.score < $1.score }
+    )
+    #expect(l.items.map(\.score) == [5, 7, 9])
+    #expect(l.groups.isEmpty)
+  }
+
+  @Test func groupsEmptyWhenCategorizeNil() async {
+    let c = await loadedCatalog(sample)
+    let l = GroupedLens<TestItem, String>(source: c)
+    #expect(l.groups.isEmpty)
+  }
+
+  @Test func groupsPopulatedWhenCategorizeProvided() async {
+    let c = await loadedCatalog(sample)
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      categorize: { $0.name.prefix(1).lowercased() }
+    )
+    let keys = l.groups.map(\.category)
+    #expect(keys == ["a", "b", "c"])
+    #expect(l.groups.first { $0.category == "a" }?.items.map(\.id).sorted() == [2, 4])
+  }
+
+  @Test func groupsOrderedByCategoryComparable() async {
+    // Priority's Comparable order is high < medium < low, NOT alphabetic.
+    // Use score to assign priority so the ordering is deterministic.
+    let c = await loadedCatalog(sample)
+    let l = GroupedLens<TestItem, Priority>(
+      source: c,
+      categorize: { item in
+        if item.score >= 8 { .high } else if item.score >= 5 { .medium } else { .low }
+      }
+    )
+    #expect(l.groups.map(\.category) == [.high, .medium, .low])
+  }
+
+  @Test func groupsRespectFilter() async {
+    let c = await loadedCatalog(sample)
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      filter: { $0.score >= 5 },
+      categorize: { $0.name.prefix(1).lowercased() }
+    )
+    // Filtered out: cherry (score 1). Remaining: banana, apple, apricot.
+    let keys = l.groups.map(\.category)
+    #expect(keys == ["a", "b"])  // no "c" group — cherry was filtered
+    #expect(l.groups.first { $0.category == "a" }?.items.count == 2)
+    #expect(l.groups.first { $0.category == "b" }?.items.count == 1)
+  }
+
+  @Test func itemsWithinGroupInheritSortOrder() async {
+    let c = await loadedCatalog(sample)
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      sort: { $0.score < $1.score },
+      categorize: { $0.name.prefix(1).lowercased() }
+    )
+    // "a" group: apple (9), apricot (7) → sorted ascending by score.
+    let a = l.groups.first { $0.category == "a" }?.items ?? []
+    #expect(a.map(\.score) == [7, 9])
+  }
+
+  @Test func updateCategoriesRecomputesGroups() async {
+    let c = await loadedCatalog(sample)
+    let l = GroupedLens<TestItem, String>(source: c)
+    #expect(l.groups.isEmpty)
+    l.updateCategories { $0.name.prefix(1).lowercased() }
+    #expect(l.groups.map(\.category) == ["a", "b", "c"])
+  }
+
+  @Test func updateCategoriesNilClearsGroupsPreservesItems() async {
+    let c = await loadedCatalog(sample)
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      categorize: { $0.name.prefix(1).lowercased() }
+    )
+    #expect(!l.groups.isEmpty)
+    let itemsBefore = l.items.map(\.id)
+    l.updateCategories(nil)
+    #expect(l.groups.isEmpty)
+    #expect(l.items.map(\.id) == itemsBefore)
+  }
+
+  @Test func updateFilterRecomputesGroups() async {
+    let c = await loadedCatalog(sample)
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      categorize: { $0.name.prefix(1).lowercased() }
+    )
+    #expect(l.groups.map(\.category) == ["a", "b", "c"])
+    l.updateFilter { $0.name.hasPrefix("a") }
+    #expect(l.groups.map(\.category) == ["a"])
+  }
+
+  @Test func updateSortRecomputesItemsWithinGroups() async {
+    let c = await loadedCatalog(sample)
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      sort: { $0.score > $1.score },  // descending
+      categorize: { $0.name.prefix(1).lowercased() }
+    )
+    #expect(l.groups.first { $0.category == "a" }?.items.map(\.score) == [9, 7])
+    l.updateSort { $0.score < $1.score }  // ascending
+    #expect(l.groups.first { $0.category == "a" }?.items.map(\.score) == [7, 9])
+  }
+
+  @Test func recomputesWhenSourceRefreshes() async {
+    let counter = Counter()
+    let c = Catalog<TestItem, TestCriteria> { _ in
+      let n = await counter.increment()
+      return [TestItem(id: n, name: "x", score: n * 10)]
+    }
+    c.load(TestCriteria(category: "a"))
+    await waitUntil { c.phase == .completed }
+    let l = GroupedLens<TestItem, Int>(source: c, categorize: { $0.score })
+    await waitUntil { l.items.count == 1 }
+    #expect(l.groups.map(\.category) == [10])
+    c.refresh()
+    await waitUntil {
+      if let cat = l.groups.first?.category, cat != 10 { true } else { false }
+    }
+    #expect(l.groups.map(\.category) == [20])
+  }
+
+  @Test func emptySourceReturnsEmpty() async {
+    let c = await loadedCatalog([])
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      categorize: { $0.name }
+    )
+    #expect(l.items.isEmpty)
+    #expect(l.groups.isEmpty)
+  }
+
+  @Test func clearsWhenSourceClearsOnCriteriaChange() async {
+    let counter = Counter()
+    let c = Catalog<TestItem, TestCriteria> { _ in
+      let n = await counter.increment()
+      if n == 1 { return [TestItem(id: 1, name: "a", score: 1)] }
+      try? await Task.sleep(for: .milliseconds(200))
+      return [TestItem(id: 2, name: "b", score: 2)]
+    }
+    c.load(TestCriteria(category: "a"))
+    await waitUntil { c.phase == .completed }
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      categorize: { $0.name }
+    )
+    await waitUntil { l.items.count == 1 }
+    #expect(!l.groups.isEmpty)
+    c.load(TestCriteria(category: "b"))
+    await waitUntil { l.items.isEmpty }
+    #expect(l.items.isEmpty)
+    #expect(l.groups.isEmpty)
+  }
+}

--- a/Tests/SplintTests/GroupedLensTests.swift
+++ b/Tests/SplintTests/GroupedLensTests.swift
@@ -23,13 +23,15 @@ private enum Priority: String, Hashable, Comparable, Sendable {
 struct GroupedLensTests {
   private func waitUntil(
     timeout: Duration = .seconds(2),
-    _ condition: () -> Bool
+    _ condition: () -> Bool,
+    sourceLocation: SourceLocation = #_sourceLocation
   ) async {
     let deadline = ContinuousClock.now.advanced(by: timeout)
     while ContinuousClock.now < deadline {
       if condition() { return }
       try? await Task.sleep(for: .milliseconds(5))
     }
+    #expect(condition(), "waitUntil timed out after \(timeout)", sourceLocation: sourceLocation)
   }
 
   private let sample: [TestItem] = [


### PR DESCRIPTION
## Summary

- New `GroupedLens<Item, Category>` — a sibling projection type alongside `Lens<Item>` for sectioned `List` / `ForEach { Section }` rendering. Exposes both `items` (filter+sort output) and a cached `groups: [(category, items)]` derived from an optional `@Sendable (Item) -> Category` closure. Groups ordered by `Category`'s `Comparable`; items within each group inherit the lens's sort.
- Bookshelf example collapses the two-lens intersection (`searchLens ∩ genreLens`) into a single `displayLens: GroupedLens<Book, String>` with a toolbar `square.stack.3d.up` menu toggling None / Author / Genre grouping. Expanded sample fixture to 15 books across multiple authors and genres so sections are visibly populated.
- New DocC article `GroupedLensGuide`, cross-linked from `LensGuide`, `Splint.md`, and `ChoosingTheRightType`.
- Fixes [#26](https://github.com/searlsco/splint/issues/26).

## Design notes

The original plan tried to extend `Lens` itself with `Lens<Item, Category: ... = Never>`, but Swift 6.3 doesn't support default generic parameters on concrete types (only protocol primary associated types — see [SE-0346](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0346-light-weight-same-type-syntax.md) and the long-dormant [Swift Forums pitches](https://forums.swift.org/t/default-generic-arguments/4960)). Adding a non-defaulted second generic would have forced every existing `Lens<Book>` call site to become `Lens<Book, Never>`. A sibling `GroupedLens` type keeps `Lens<Item>` clean and makes the shape difference (scalar `items` vs. grouped `groups`) visible at the type level.

Standalone `@Observable` class rather than a wrapper around `Lens` — parallel filter/sort/observe logic is ~30 lines and avoids layered observation + double allocation. A shared helper can be extracted if a third projection type ever justifies it.

## Test plan

- [x] 100% line coverage preserved on `Sources/Splint/`, including the new `GroupedLens.swift` (53/53 lines).
- [x] New `GroupedLensTests` suite (12 cases): nil/non-nil categorize, Comparable ordering via non-alphabetic `Priority` enum, filter/sort interaction, toggle on/off, source refresh, clear on criteria change.
- [x] New `GroupedLensLargeN` suite: N=1000 correctness + invariant that `categorize` is invoked exactly once per filtered item per recompute.
- [x] `GroupedLens_1M_initFilterSortGrouping` + `GroupedLens_1M_updateGrouping` benchmarks (thresholds to be captured on first `SPLINT_BENCHMARK=1 script/benchmark` run).
- [x] Bookshelf example builds on SPM; `ViewLogicTests` updated to exercise the single-lens composition + grouping menu.
- [x] `./script/test` green (32/32 tests across 5 example suites + the library suites), `./script/lint` clean.
- [ ] Manual Bookshelf run to confirm the toolbar menu toggles grouping smoothly on iOS and macOS (deferred — plan calls this out as a verification step).

## Incidental cleanup

- Fixed silent-timeout `waitUntil` helper in the three authored/rewritten test files (caught by the testing-antipatterns reviewer). The same helper is duplicated in other pre-existing test files — repo-wide cleanup is a separate, queued follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)