### PR TITLE
Add Catalog.initialItems: seed parameter (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `Catalog.init(initialItems:fetch:)` — seed a catalog with a snapshot
+  so `items` is non-empty from moment zero. Lets consumers show a
+  disk-cached copy immediately on cold launch instead of flashing an
+  empty state while the first fetch runs. `Lens` and `GroupedLens`
+  built on top see the seed immediately. `phase` stays `.idle` until
+  a real `load()` completes
+  ([#29](https://github.com/searlsco/splint/issues/29)).
+
+### Changed
+
+- `Catalog.load(_:)` now preserves `items` on the first load (when
+  the prior criteria was `nil`) instead of clearing them. Clearing on
+  criteria change still applies when transitioning between two
+  distinct non-nil criteria. This is what makes `initialItems:` seeds
+  stay visible through the first fetch.
+
 ## [0.2.0] - 2026-04-19
 
 ### Added

--- a/Example/Bookshelf/ContentView.swift
+++ b/Example/Bookshelf/ContentView.swift
@@ -24,7 +24,17 @@ public struct ContentView: View {
 
   public init(client: BookClient) {
     self.client = client
-    let c = Catalog<Book, BookCriteria>(fetch: client.fetchBooks)
+    // Seed the catalog with a tiny cached snapshot so the list renders
+    // immediately on cold launch instead of flashing empty while the
+    // async `fetchBooks` runs. Real apps would read this from a disk
+    // cache keyed by the last successful fetch; for the example a
+    // handful of hardcoded entries suffices to demonstrate the seam.
+    let cached: [Book] = [
+      Book(id: "seed-1", title: "Cached: The Pragmatic Programmer", author: "Hunt & Thomas", genre: "Programming", year: 1999),
+      Book(id: "seed-2", title: "Cached: Clean Code", author: "Robert C. Martin", genre: "Programming", year: 2008),
+      Book(id: "seed-3", title: "Cached: Refactoring", author: "Martin Fowler", genre: "Programming", year: 1999),
+    ]
+    let c = Catalog<Book, BookCriteria>(initialItems: cached, fetch: client.fetchBooks)
     self._catalog = State(initialValue: c)
     self._displayLens = State(initialValue: GroupedLens<Book, String>(source: c))
   }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ let catalog = Catalog<Book, BookCriteria> { criteria in
     try await api.fetchBooks(in: criteria.libraryID)
 }
 
+// Or seed from a disk cache so the UI renders immediately on cold launch.
+// The seed stays visible through the first load() until the fetch lands.
+//   Catalog<Book, BookCriteria>(initialItems: cachedBooks) { criteria in … }
+
 catalog.load(BookCriteria(libraryID: "main"))
 
 let favorites = Lens<Book>(source: catalog, filter: { $0.isFavorite })
@@ -164,7 +168,10 @@ The most important API distinction in Splint:
 
 - `catalog.load(newCriteria)` — criteria changed; old items are *wrong*
   (channel A's programs when you asked for channel B). Clears items
-  immediately so the view shows loading, not wrong data.
+  immediately so the view shows loading, not wrong data. The one
+  exception is the very first `load()`: the prior criteria was `nil`,
+  so there are no "wrong" items to wipe — any seeded items from
+  `initialItems:` stay visible until the fetch lands.
 - `catalog.refresh()` — same criteria; items stay visible during fetch.
   This is pull-to-refresh, periodic polling, "show stale and update in
   place." No-op if `load()` has never been called.
@@ -216,6 +223,29 @@ init(client: BookClient) {
 No singletons, no late-binding, no service locators. The same rule
 applies to `Lens` filter/sort closures — see "Lens closures capture
 once" below.
+
+### Seeding from a cache
+
+Cold launch shouldn't have to flash an empty view for the 500ms–2s the
+first fetch takes. If you have a disk-cached snapshot of the last
+successful fetch, pass it to `Catalog` via `initialItems:`:
+
+```swift
+let cached: [Book] = cache.load(key: "books", as: [Book].self) ?? []
+let catalog = Catalog<Book, BookCriteria>(initialItems: cached) { criteria in
+    try await api.fetchBooks(in: criteria.libraryID)
+}
+```
+
+Semantics:
+
+- `catalog.items` is non-empty from moment zero — any `Lens` or
+  `GroupedLens` built on top sees the seed immediately.
+- `catalog.phase` stays `.idle` until a real `load()` completes.
+  Seeding is not a completed fetch.
+- The first `load()` preserves the seed until the fetch lands, so the
+  view doesn't flash empty between "we showed the cache" and "the
+  network answered."
 
 ## Narrowly-scoped catalogs over client-side filtering
 

--- a/Sources/Splint/Catalog.swift
+++ b/Sources/Splint/Catalog.swift
@@ -22,9 +22,12 @@ public struct NoCriteria: Equatable, Sendable {
 @Observable
 @MainActor
 public final class Catalog<Item: Resource, Criteria: Equatable & Sendable> {
-  /// Items returned by the most recent fetch. Cleared when criteria change
-  /// in ``load(_:)``; preserved when ``refresh()`` is called with the same
-  /// criteria.
+  /// Items returned by the most recent fetch, or the seed passed to
+  /// ``init(initialItems:fetch:)`` before any fetch has completed.
+  /// Cleared when ``load(_:)`` is called with criteria that differ from
+  /// the current non-nil criteria; preserved across a first load (so
+  /// seeded items stay visible until the first fetch completes) and
+  /// across ``refresh()``.
   public private(set) var items: [Item] = []
   /// The criteria used for the most recent (or in-flight) load.
   public private(set) var criteria: Criteria?
@@ -43,15 +46,33 @@ public final class Catalog<Item: Resource, Criteria: Equatable & Sendable> {
   @_spi(Internal)
   public var currentTask: Task<Void, Never>? { task }
 
-  public init(fetch: @escaping @Sendable (Criteria) async throws -> [Item]) {
+  /// - Parameters:
+  ///   - initialItems: A seed populating ``items`` before any fetch. Use
+  ///     this to show a cached/snapshot copy on cold launch so consumers
+  ///     of ``items`` (including ``Lens`` and ``GroupedLens``) have data
+  ///     to render immediately. ``phase`` stays `.idle` until a real
+  ///     ``load(_:)`` completes — seeding is not a completed fetch. The
+  ///     seed remains visible through the first ``load(_:)``; it is
+  ///     only cleared when ``load(_:)`` is called with criteria that
+  ///     differ from an existing non-nil criteria.
+  ///   - fetch: The async fetch closure invoked by ``load(_:)`` and
+  ///     ``refresh()``.
+  public init(
+    initialItems: [Item] = [],
+    fetch: @escaping @Sendable (Criteria) async throws -> [Item]
+  ) {
+    self.items = initialItems
     self.fetch = fetch
   }
 
-  /// Load with `criteria`. If the criteria differ from the current ones,
-  /// clears ``items`` immediately so the view shows a loading state rather
-  /// than wrong data from the previous criteria.
+  /// Load with `criteria`. If `criteria` differs from an existing non-nil
+  /// criteria, clears ``items`` immediately so the view shows a loading
+  /// state rather than wrong data from the previous criteria. The first
+  /// load after init (criteria was `nil`) preserves any existing items —
+  /// including seed values from ``init(initialItems:fetch:)`` — so the
+  /// seed stays visible until the fetch completes.
   public func load(_ criteria: Criteria) {
-    if self.criteria != criteria {
+    if let existing = self.criteria, existing != criteria {
       items = []
     }
     self.criteria = criteria

--- a/Tests/SplintTests/CatalogTests.swift
+++ b/Tests/SplintTests/CatalogTests.swift
@@ -187,6 +187,50 @@ struct CatalogTests {
     #expect(c[id: 99] == nil)
   }
 
+  @Test func initialItemsSeedsItemsBeforeAnyLoad() {
+    let seed = [TestItem(id: 1, name: "seed", score: 0)]
+    let c = Catalog<TestItem, TestCriteria>(initialItems: seed) { _ in [] }
+    #expect(c.items == seed)
+    #expect(c.phase == .idle)
+    #expect(c.criteria == nil)
+    #expect(c.lastLoaded == nil)
+  }
+
+  @Test func firstLoadPreservesSeededItemsUntilFetchCompletes() async {
+    let gate = AsyncGate()
+    let seed = [TestItem(id: 1, name: "seed", score: 0)]
+    let fresh = [TestItem(id: 2, name: "fresh", score: 1)]
+    let c = Catalog<TestItem, TestCriteria>(initialItems: seed) { _ in
+      await gate.wait()
+      return fresh
+    }
+    c.load(TestCriteria(category: "x"))
+    await waitUntil { c.phase == .running }
+    // Seed is still visible while fetch is in flight.
+    #expect(c.items == seed)
+    await gate.open()
+    await waitUntil { c.items == fresh }
+  }
+
+  @Test func seededCatalogClearsWhenSwitchingBetweenNonNilCriteria() async {
+    let gate = AsyncGate()
+    let counter = Counter()
+    let seed = [TestItem(id: 0, name: "seed", score: 0)]
+    let c = Catalog<TestItem, TestCriteria>(initialItems: seed) { _ in
+      let n = await counter.increment()
+      if n > 1 { await gate.wait() }
+      return [TestItem(id: n, name: "fetched", score: n)]
+    }
+    c.load(TestCriteria(category: "a"))
+    await waitUntil { c.phase == .completed }
+    #expect(c.items.first?.name == "fetched")
+    c.load(TestCriteria(category: "b"))
+    // Clearing is synchronous when switching between distinct non-nil criteria.
+    #expect(c.items.isEmpty)
+    await gate.open()
+    await waitUntil { c.phase == .completed && !c.items.isEmpty }
+  }
+
   @Test func noCriteriaConvenienceWorksWithoutArgs() async {
     let c = Catalog<TestItem, NoCriteria> {
       [TestItem(id: 1, name: "A", score: 1)]

--- a/Tests/SplintTests/GroupedLensTests.swift
+++ b/Tests/SplintTests/GroupedLensTests.swift
@@ -174,6 +174,16 @@ struct GroupedLensTests {
     #expect(l.groups.isEmpty)
   }
 
+  @Test func reflectsSeededItemsImmediately() {
+    let c = Catalog<TestItem, TestCriteria>(initialItems: sample) { _ in [] }
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      categorize: { $0.name.prefix(1).lowercased() }
+    )
+    #expect(l.items.count == sample.count)
+    #expect(l.groups.map(\.category) == ["a", "b", "c"])
+  }
+
   @Test func clearsWhenSourceClearsOnCriteriaChange() async {
     let counter = Counter()
     let c = Catalog<TestItem, TestCriteria> { _ in

--- a/Tests/SplintTests/LensTests.swift
+++ b/Tests/SplintTests/LensTests.swift
@@ -94,6 +94,12 @@ struct LensTests {
     #expect(l.items.isEmpty)
   }
 
+  @Test func reflectsSeededItemsImmediately() {
+    let c = Catalog<TestItem, TestCriteria>(initialItems: sample) { _ in [] }
+    let l = Lens<TestItem>(source: c, sort: { $0.score < $1.score })
+    #expect(l.items.map(\.score) == [1, 5, 9])
+  }
+
   @Test func clearsWhenSourceClearsOnCriteriaChange() async {
     // First load populates.
     let counter = Counter()


### PR DESCRIPTION
Closes #29.

## Summary

- New `Catalog.init(initialItems:fetch:)` lets consumers seed a catalog with a cached snapshot so `items` is non-empty from moment zero. `Lens` / `GroupedLens` built on top see the seed immediately — no more empty flash on cold launch.
- `Catalog.load(_:)` now preserves `items` on the first load (nil → first non-nil criteria) instead of clearing them. Clearing still applies when switching between two distinct non-nil criteria. This is what keeps seeded items visible through the first fetch.
- `phase` stays `.idle` for a seeded catalog until a real `load()` completes — seeding is not a completed fetch.

## What changed

- [Sources/Splint/Catalog.swift](../blob/claude/quirky-lewin-329aa3/Sources/Splint/Catalog.swift) — new `initialItems:` parameter; revised clearing rule in `load()`; DocC updated.
- Tests:
  - `CatalogTests` — `initialItemsSeedsItemsBeforeAnyLoad`, `firstLoadPreservesSeededItemsUntilFetchCompletes`, `seededCatalogClearsWhenSwitchingBetweenNonNilCriteria`.
  - `LensTests` — `reflectsSeededItemsImmediately`.
  - `GroupedLensTests` — `reflectsSeededItemsImmediately` (the load-bearing test for the issue's motivating scenario).
- `README.md` — Quick-start snippet gets a seed comment; new "Seeding from a cache" subsection under Catalog lifecycle; `load()` wording refined.
- `CHANGELOG.md` — Unreleased Added/Changed entries.
- `Example/Bookshelf/ContentView.swift` — seeded with three sample books to demonstrate cold-launch behavior in the committed example app.

## Test plan

- [x] `./script/test_fast` — 97 tests pass
- [x] `./script/test` — full suite + 100% line coverage on `Sources/Splint/` + Bookshelf integration tests pass
- [x] `./script/lint` — clean
- [ ] Open `Example/Bookshelf.xcodeproj` and confirm seeded rows appear on cold launch and are replaced by fetched books when the async load completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)