### PR TITLE
Expose `refresh()` on Lens and GroupedLens

### DIFF
--- a/Sources/Splint/GroupedLens.swift
+++ b/Sources/Splint/GroupedLens.swift
@@ -15,7 +15,7 @@ import Observation
 /// see `GroupedLens<Item, Category>`, not `GroupedLens<Item, Category,
 /// Criteria>`.
 ///
-/// **Performance.** `recompute()` is O(n) for the filter pass, O(n log
+/// **Performance.** `refresh()` is O(n) for the filter pass, O(n log
 /// n) for the sort (stdlib introsort) when one is set, and O(n + k log
 /// k) for the grouping pass (k = distinct categories) when a
 /// categorizer is set. Under ~1k items this is negligible; for larger
@@ -44,8 +44,14 @@ public final class GroupedLens<
   public init<Criteria: Equatable & Sendable>(
     source: Catalog<Item, Criteria>,
     /// Predicate applied to each item. Captured once at init; re-runs
-    /// only when `updateFilter` is called. Do not capture mutable view
-    /// state — drive `updateFilter` from `.onChange(of:)` instead.
+    /// only when ``updateFilter(_:)`` or ``refresh()`` is called. Do not
+    /// capture mutable *observable* view state — drive
+    /// ``updateFilter(_:)`` from `.onChange(of:)` instead. For exogenous
+    /// state the lens cannot practically observe (clocks, locale,
+    /// reachability, feature flags, newly-granted permissions, cleared
+    /// caches, RNG) it's fine for the closure to read that state
+    /// directly; call ``refresh()`` to re-run the projection when it
+    /// changes.
     filter: @escaping @Sendable (Item) -> Bool = { _ in true },
     /// Comparator applied after filtering. Same capture rules as
     /// `filter`.
@@ -61,31 +67,43 @@ public final class GroupedLens<
     self.filter = filter
     self.order = sort
     self.categorize = categorize
-    recompute()
+    refresh()
     observe()
   }
 
   /// Replace the filter predicate and recompute.
   public func updateFilter(_ filter: @escaping @Sendable (Item) -> Bool) {
     self.filter = filter
-    recompute()
+    refresh()
   }
 
   /// Replace the sort predicate and recompute. Pass `nil` to remove
   /// sorting and return to source order.
   public func updateSort(_ sort: (@Sendable (Item, Item) -> Bool)?) {
     self.order = sort
-    recompute()
+    refresh()
   }
 
   /// Replace the categorizer and recompute. Pass `nil` to clear
   /// ``groups`` back to empty without losing ``items``.
   public func updateCategories(_ categorize: (@Sendable (Item) -> Category)?) {
     self.categorize = categorize
-    recompute()
+    refresh()
   }
 
-  private func recompute() {
+  /// Re-run the current filter, sort, and categorizer over the source
+  /// catalog's items without changing the closures themselves. The
+  /// lens automatically refreshes when the source changes or when you
+  /// call ``updateFilter(_:)`` / ``updateSort(_:)`` /
+  /// ``updateCategories(_:)`` — reach for `refresh()` only when any of
+  /// those closures reads from state the lens cannot (or deliberately
+  /// does not) observe: clocks (`Date.now`, "due within the next
+  /// hour"), locale changes, reachability / online status, file-system
+  /// mtimes, feature flags, newly-granted permissions, cleared caches,
+  /// or RNG-based shuffles. Both ``items`` and ``groups`` are
+  /// recomputed. For state you *can* observe, `.onChange(of:)` plus
+  /// the matching `update…` method remains the right pattern.
+  public func refresh() {
     var result = sourceItems().filter(self.filter)
     if let order { result.sort(by: order) }
     items = result
@@ -105,13 +123,13 @@ public final class GroupedLens<
 
   private func observe() {
     // Re-arm tracking on every change. onChange fires *before* the mutation
-    // is committed, so defer the recompute to the next MainActor hop.
+    // is committed, so defer the refresh to the next MainActor hop.
     withObservationTracking { [weak self] in
       _ = self?.sourceItems()
     } onChange: { [weak self] in
       Task { @MainActor [weak self] in
         guard let self else { return }
-        self.recompute()
+        self.refresh()
         self.observe()
       }
     }

--- a/Sources/Splint/Lens.swift
+++ b/Sources/Splint/Lens.swift
@@ -8,7 +8,7 @@ import Observation
 /// The source catalog's `Criteria` type is erased at init: call sites see
 /// `Lens<Channel>`, not `Lens<Channel, ProviderCriteria>`.
 ///
-/// **Performance.** `recompute()` is O(n) for the filter pass plus
+/// **Performance.** `refresh()` is O(n) for the filter pass plus
 /// O(n log n) for the sort (stdlib introsort) when one is set. Under ~1k
 /// items this is negligible; for larger datasets, prefer server-side
 /// filtering via the catalog's `Criteria` over a client-side `Lens`.
@@ -24,8 +24,13 @@ public final class Lens<Item: Resource> {
   public init<Criteria: Equatable & Sendable>(
     source: Catalog<Item, Criteria>,
     /// Predicate applied to each item. Captured once at init; re-runs only
-    /// when `updateFilter` is called. Do not capture mutable view state —
-    /// drive `updateFilter` from `.onChange(of:)` instead.
+    /// when ``updateFilter(_:)`` or ``refresh()`` is called. Do not capture
+    /// mutable *observable* view state — drive ``updateFilter(_:)`` from
+    /// `.onChange(of:)` instead. For exogenous state the lens cannot
+    /// practically observe (clocks, locale, reachability, feature flags,
+    /// newly-granted permissions, cleared caches, RNG) it's fine for the
+    /// closure to read that state directly; call ``refresh()`` to re-run
+    /// the projection when it changes.
     filter: @escaping @Sendable (Item) -> Bool = { _ in true },
     /// Comparator applied after filtering. Same capture rules as `filter`.
     sort: (@Sendable (Item, Item) -> Bool)? = nil
@@ -33,24 +38,35 @@ public final class Lens<Item: Resource> {
     self.sourceItems = { source.items }
     self.filter = filter
     self.order = sort
-    recompute()
+    refresh()
     observe()
   }
 
   /// Replace the filter predicate and recompute.
   public func updateFilter(_ filter: @escaping @Sendable (Item) -> Bool) {
     self.filter = filter
-    recompute()
+    refresh()
   }
 
   /// Replace the sort predicate and recompute. Pass `nil` to remove
   /// sorting and return to source order.
   public func updateSort(_ sort: (@Sendable (Item, Item) -> Bool)?) {
     self.order = sort
-    recompute()
+    refresh()
   }
 
-  private func recompute() {
+  /// Re-run the current filter and sort over the source catalog's items
+  /// without changing the closures themselves. The lens automatically
+  /// refreshes when the source changes or when you call
+  /// ``updateFilter(_:)`` / ``updateSort(_:)`` — reach for `refresh()`
+  /// only when the filter or sort closure reads from state the lens
+  /// cannot (or deliberately does not) observe: clocks (`Date.now`,
+  /// "due within the next hour"), locale changes, reachability / online
+  /// status, file-system mtimes, feature flags, newly-granted
+  /// permissions, cleared caches, or RNG-based shuffles. For state you
+  /// *can* observe, `.onChange(of:)` plus ``updateFilter(_:)`` remains
+  /// the right pattern.
+  public func refresh() {
     var result = sourceItems().filter(self.filter)
     if let order { result.sort(by: order) }
     items = result
@@ -58,13 +74,13 @@ public final class Lens<Item: Resource> {
 
   private func observe() {
     // Re-arm tracking on every change. onChange fires *before* the mutation
-    // is committed, so defer the recompute to the next MainActor hop.
+    // is committed, so defer the refresh to the next MainActor hop.
     withObservationTracking { [weak self] in
       _ = self?.sourceItems()
     } onChange: { [weak self] in
       Task { @MainActor [weak self] in
         guard let self else { return }
-        self.recompute()
+        self.refresh()
         self.observe()
       }
     }

--- a/Sources/Splint/Splint.docc/GroupedLensGuide.md
+++ b/Sources/Splint/Splint.docc/GroupedLensGuide.md
@@ -84,21 +84,46 @@ both the flat list and every section.
 
 ## Performance
 
-`recompute()` is O(n) for filter, O(n log n) for sort, and O(n + k
-log k) for grouping (k = distinct categories). One pass per source
-change or predicate update. Under ~1k items all three are negligible.
-For larger datasets, consider whether filtering belongs in the fetch
-closure (server-side via the catalog's `Criteria`) rather than in a
-client-side lens.
+``GroupedLens/refresh()`` is O(n) for filter, O(n log n) for sort, and
+O(n + k log k) for grouping (k = distinct categories). One pass per
+source change or predicate update. Under ~1k items all three are
+negligible. For larger datasets, consider whether filtering belongs in
+the fetch closure (server-side via the catalog's `Criteria`) rather
+than in a client-side lens.
+
+## Refreshing against exogenous state
+
+``GroupedLens`` automatically refreshes when its source changes or
+when you call ``GroupedLens/updateFilter(_:)``,
+``GroupedLens/updateSort(_:)``, or
+``GroupedLens/updateCategories(_:)``. For closures that read from
+state the lens cannot (or deliberately does not) observe — clocks,
+locale changes, reachability, feature flags, newly-granted
+permissions, cleared caches, RNG-based shuffles — call
+``GroupedLens/refresh()`` to re-run the projection without changing
+the closures themselves:
+
+```swift
+// Category depends on wall-clock time. The lens can't observe `Date.now`.
+let lens = GroupedLens<Task, String>(
+  source: catalog,
+  categorize: { task in task.dueDate < .now ? "Overdue" : "Upcoming" })
+
+// Somewhere driving a minute-tick timer:
+lens.refresh()
+```
+
+For state you *can* observe, `.onChange(of:)` plus the matching
+`update…` method remains the right pattern — see the next section.
 
 ## Closures capture once
 
 ``GroupedLens`` captures `filter`, `sort`, and `categorize` at init.
 They re-run only on ``GroupedLens/updateFilter(_:)``,
-``GroupedLens/updateSort(_:)``, and
-``GroupedLens/updateCategories(_:)`` — not when variables they
-reference change. Capturing mutable view state at init compiles and
-looks correct, and fails silently:
+``GroupedLens/updateSort(_:)``, ``GroupedLens/updateCategories(_:)``,
+or ``GroupedLens/refresh()`` — not when observable variables they
+reference change. Capturing mutable *observable* view state at init
+compiles and looks correct, and fails silently:
 
 ```swift
 // ❌ `grouping` capture goes stale

--- a/Sources/Splint/Splint.docc/LensGuide.md
+++ b/Sources/Splint/Splint.docc/LensGuide.md
@@ -28,12 +28,37 @@ negligible. For larger datasets, consider whether filtering belongs in
 the fetch closure (server-side filtering via the catalog's `Criteria`)
 rather than in a client-side lens.
 
+## Refreshing against exogenous state
+
+``Lens`` automatically refreshes when its source changes or when you
+call ``Lens/updateFilter(_:)`` / ``Lens/updateSort(_:)``. For closures
+that read from state the lens cannot (or deliberately does not)
+observe — clocks, locale changes, reachability, feature flags,
+newly-granted permissions, cleared caches, RNG-based shuffles — call
+``Lens/refresh()`` to re-run the projection without changing the
+closures themselves:
+
+```swift
+// Filter depends on wall-clock time. The lens can't observe `Date.now`.
+let lens = Lens<Task>(
+  source: catalog,
+  filter: { $0.dueDate < .now.addingTimeInterval(3600) })
+
+// Somewhere driving a minute-tick timer:
+lens.refresh()
+```
+
+For state you *can* observe, `.onChange(of:)` plus
+``Lens/updateFilter(_:)`` remains the right pattern — see the next
+section.
+
 ## Closures capture once
 
 ``Lens`` captures `filter` and `sort` at init. They re-run only on
-`updateFilter` / `updateSort` — not when variables they reference
-change. Capturing mutable view state at init compiles and looks
-correct, and fails silently:
+``Lens/updateFilter(_:)`` / ``Lens/updateSort(_:)`` (or
+``Lens/refresh()``) — not when observable variables they reference
+change. Capturing mutable *observable* view state at init compiles and
+looks correct, and fails silently:
 
 ```swift
 // ❌ minRating capture goes stale — Lens never sees changes

--- a/Tests/SplintTests/CatalogTests.swift
+++ b/Tests/SplintTests/CatalogTests.swift
@@ -243,6 +243,14 @@ struct CatalogTests {
 
 // MARK: - Test helpers
 
+/// A reference cell used by tests to stand in for exogenous state that a
+/// Splint closure reads without the container observing it — e.g. the
+/// motivation for `Lens.refresh()` / `GroupedLens.refresh()`.
+final class MutableBox<T>: @unchecked Sendable {
+  var value: T
+  init(value: T) { self.value = value }
+}
+
 actor Counter {
   private var _value: Int = 0
   var value: Int { _value }

--- a/Tests/SplintTests/GroupedLensLargeNTests.swift
+++ b/Tests/SplintTests/GroupedLensLargeNTests.swift
@@ -44,12 +44,12 @@ struct GroupedLensLargeNTests {
     }
   }
 
-  // Composition invariants: `recompute()` must invoke the categorizer
+  // Composition invariants: `refresh()` must invoke the categorizer
   // exactly once per item that passes the filter, per call. Guards a
   // refactor that accidentally double-categorizes. Split by trigger so
-  // a failure identifies *which* recompute over-categorized.
+  // a failure identifies *which* refresh over-categorized.
 
-  @Test func initRecomputeInvokesCategorizeOncePerFilteredItem() async {
+  @Test func initRefreshInvokesCategorizeOncePerFilteredItem() async {
     let c = await loadedCatalog(makeItems(n))
     let counter = LockCounter()
 
@@ -62,10 +62,10 @@ struct GroupedLensLargeNTests {
       }
     )
     _ = l  // keep observation alive
-    #expect(counter.value == 500, "init's recompute must invoke categorize exactly once per filtered item")
+    #expect(counter.value == 500, "init's refresh must invoke categorize exactly once per filtered item")
   }
 
-  @Test func updateSortRecomputeInvokesCategorizeOncePerFilteredItem() async {
+  @Test func updateSortRefreshInvokesCategorizeOncePerFilteredItem() async {
     let c = await loadedCatalog(makeItems(n))
     let counter = LockCounter()
 
@@ -79,7 +79,7 @@ struct GroupedLensLargeNTests {
     )
     let afterInit = counter.value
     l.updateSort { $0.score < $1.score }
-    #expect(counter.value - afterInit == 500, "updateSort's recompute must invoke categorize exactly once per filtered item, not 2×")
+    #expect(counter.value - afterInit == 500, "updateSort's refresh must invoke categorize exactly once per filtered item, not 2×")
   }
 
   @Test func groupingDoesNotDegradeSortStability() async {

--- a/Tests/SplintTests/GroupedLensTests.swift
+++ b/Tests/SplintTests/GroupedLensTests.swift
@@ -164,6 +164,25 @@ struct GroupedLensTests {
     #expect(l.groups.map(\.category) == [20])
   }
 
+  @Test func refreshReRunsCategorizerWithCurrentClosureState() async {
+    let c = await loadedCatalog(sample)
+    // Exogenous toggle that the categorizer reads without the lens
+    // observing it — mirrors the time/locale/flag scenarios.
+    let byFirstLetter = MutableBox(value: true)
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      sort: { $0.score < $1.score },
+      categorize: { item in
+        byFirstLetter.value ? String(item.name.prefix(1)) : "all"
+      }
+    )
+    #expect(Set(l.groups.map(\.category)) == Set(["b", "a", "c"]))
+    byFirstLetter.value = false
+    l.refresh()
+    #expect(l.groups.map(\.category) == ["all"])
+    #expect(l.groups.first?.items.map(\.score) == [1, 5, 7, 9])
+  }
+
   @Test func emptySourceReturnsEmpty() async {
     let c = await loadedCatalog([])
     let l = GroupedLens<TestItem, String>(

--- a/Tests/SplintTests/LensLargeNTests.swift
+++ b/Tests/SplintTests/LensLargeNTests.swift
@@ -122,10 +122,10 @@ struct LensLargeNTests {
     }
   }
 
-  // Composition invariant: `recompute()` must invoke the filter exactly
+  // Composition invariant: `refresh()` must invoke the filter exactly
   // once per source item per call. Guards a refactor that accidentally
   // double-filters (e.g. filtering then re-filtering after sort).
-  @Test func recomputeInvokesFilterExactlyOncePerItem() async {
+  @Test func refreshInvokesFilterExactlyOncePerItem() async {
     let c = await loadedCatalog(makeItems(n))
     let counter = LockCounter()
 
@@ -136,10 +136,10 @@ struct LensLargeNTests {
         return true
       })
     #expect(l.items.count == n)
-    #expect(counter.value == n, "init's recompute must invoke filter exactly N times")
+    #expect(counter.value == n, "init's refresh must invoke filter exactly N times")
 
-    // updateSort triggers one additional recompute → one additional pass.
+    // updateSort triggers one additional refresh → one additional pass.
     l.updateSort { $0.score < $1.score }
-    #expect(counter.value == 2 * n, "updateSort's recompute must invoke filter exactly N more times, not 2N")
+    #expect(counter.value == 2 * n, "updateSort's refresh must invoke filter exactly N more times, not 2N")
   }
 }

--- a/Tests/SplintTests/LensTests.swift
+++ b/Tests/SplintTests/LensTests.swift
@@ -100,6 +100,30 @@ struct LensTests {
     #expect(l.items.map(\.score) == [1, 5, 9])
   }
 
+  @Test func refreshReRunsFilterWithCurrentClosureState() async {
+    let c = await loadedCatalog(sample)
+    // Exogenous state the filter reads without the lens observing it.
+    let threshold = MutableBox(value: 10)
+    let l = Lens<TestItem>(source: c, filter: { $0.score >= threshold.value })
+    #expect(l.items.isEmpty)
+    threshold.value = 5
+    l.refresh()
+    #expect(Set(l.items.map(\.id)) == Set([1, 2]))
+  }
+
+  @Test func refreshReRunsSortWithCurrentClosureState() async {
+    let c = await loadedCatalog(sample)
+    let ascending = MutableBox(value: true)
+    let l = Lens<TestItem>(
+      source: c,
+      sort: { a, b in ascending.value ? a.score < b.score : a.score > b.score }
+    )
+    #expect(l.items.map(\.score) == [1, 5, 9])
+    ascending.value = false
+    l.refresh()
+    #expect(l.items.map(\.score) == [9, 5, 1])
+  }
+
   @Test func clearsWhenSourceClearsOnCriteriaChange() async {
     // First load populates.
     let counter = Counter()


### PR DESCRIPTION
## Summary

- Renames the private `recompute()` on `Lens` and `GroupedLens` to `refresh()` and makes it `public`, so callers can force a re-projection when the filter/sort/categorizer closure reads from state the lens can't observe (clocks, locale, reachability, feature flags, newly-granted permissions, cleared caches, RNG).
- Softens the "don't capture mutable view state" warning in both init docstrings and DocC guides to scope it to *observable* view state, and points at `refresh()` as the intended escape hatch for exogenous state. Naming mirrors `Catalog.refresh()` for vocabulary consistency across Splint.
- Adds three behavior tests driving the new API with a `MutableBox`-backed exogenous toggle — one each for filter, sort, and categorizer.

## Test plan

- [x] `script/test_fast` green
- [x] `script/test` green, 100.00% coverage on `Sources/Splint/Lens.swift` and `Sources/Splint/GroupedLens.swift`
- [x] `script/lint` clean
- [x] New tests fail before the rename and pass after