### PR TITLE
Aggregate-aware `categorize` overload on `GroupedLens`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `GroupedLens` categorizer overload that receives the full
+  filtered+sorted collection alongside each item:
+  `(Item, [Item]) -> Category`. Enables aggregate-aware bucketing
+  (percentiles, above/below median, rank-based groups) without
+  precomputing aggregates outside the lens. Available on both `init`
+  and `updateCategories(_:)`; the existing `(Item) -> Category` form
+  is unchanged and remains the default.
 - `Lens.refresh()` and `GroupedLens.refresh()` — public entry points
   that re-run the current filter, sort, and (for `GroupedLens`)
   categorizer over the source catalog's items without changing the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `Lens.refresh()` and `GroupedLens.refresh()` — public entry points
+  that re-run the current filter, sort, and (for `GroupedLens`)
+  categorizer over the source catalog's items without changing the
+  closures themselves. Intended for predicates that read from state
+  the lens cannot practically observe: clocks (`Date.now`,
+  time-windowed filters), locale changes, reachability / online
+  status, feature flags, newly-granted permissions, cleared caches,
+  and RNG-based shuffles. Previously this required calling
+  `updateFilter` (or `updateSort` / `updateCategories`) with an
+  identical closure
+  ([#31](https://github.com/searlsco/splint/pull/31)).
+
+### Changed
+
+- `Lens` and `GroupedLens` init-parameter documentation: the "do not
+  capture mutable view state" warning now scopes to *observable* view
+  state and points at `refresh()` as the escape hatch for exogenous
+  state. The underlying advice (observable inputs flow through
+  `.onChange(of:)` + `updateFilter`) is unchanged; the guidance just
+  no longer discourages legitimate exogenous-state patterns.
+
 ## [0.3.0] - 2026-04-20
 
 ### Added

--- a/Sources/Splint/GroupedLens.swift
+++ b/Sources/Splint/GroupedLens.swift
@@ -39,7 +39,7 @@ public final class GroupedLens<
   @ObservationIgnored private let sourceItems: @MainActor () -> [Item]
   @ObservationIgnored private var filter: @Sendable (Item) -> Bool
   @ObservationIgnored private var order: (@Sendable (Item, Item) -> Bool)?
-  @ObservationIgnored private var categorize: (@Sendable (Item) -> Category)?
+  @ObservationIgnored private var categorize: (@Sendable (Item, [Item]) -> Category)?
 
   public init<Criteria: Equatable & Sendable>(
     source: Catalog<Item, Criteria>,
@@ -66,6 +66,27 @@ public final class GroupedLens<
     self.sourceItems = { source.items }
     self.filter = filter
     self.order = sort
+    self.categorize = categorize.map { simple -> @Sendable (Item, [Item]) -> Category in
+      { item, _ in simple(item) }
+    }
+    refresh()
+    observe()
+  }
+
+  /// Aggregate-aware variant. The categorizer receives the current item
+  /// *and* the full filtered+sorted collection, enabling bucketing that
+  /// depends on aggregates (percentiles, above/below median, rank).
+  /// `all` is the same array exposed as ``items``; it has already had
+  /// `filter` and `sort` applied.
+  public init<Criteria: Equatable & Sendable>(
+    source: Catalog<Item, Criteria>,
+    filter: @escaping @Sendable (Item) -> Bool = { _ in true },
+    sort: (@Sendable (Item, Item) -> Bool)? = nil,
+    categorize: @escaping @Sendable (Item, [Item]) -> Category
+  ) {
+    self.sourceItems = { source.items }
+    self.filter = filter
+    self.order = sort
     self.categorize = categorize
     refresh()
     observe()
@@ -87,6 +108,15 @@ public final class GroupedLens<
   /// Replace the categorizer and recompute. Pass `nil` to clear
   /// ``groups`` back to empty without losing ``items``.
   public func updateCategories(_ categorize: (@Sendable (Item) -> Category)?) {
+    self.categorize = categorize.map { simple -> @Sendable (Item, [Item]) -> Category in
+      { item, _ in simple(item) }
+    }
+    refresh()
+  }
+
+  /// Aggregate-aware variant of ``updateCategories(_:)``. The closure
+  /// receives the current item and the full filtered+sorted collection.
+  public func updateCategories(_ categorize: @escaping @Sendable (Item, [Item]) -> Category) {
     self.categorize = categorize
     refresh()
   }
@@ -114,7 +144,7 @@ public final class GroupedLens<
     }
     var buckets: [Category: [Item]] = [:]
     for item in result {
-      buckets[categorize(item), default: []].append(item)
+      buckets[categorize(item, result), default: []].append(item)
     }
     groups = buckets.keys.sorted().map { key in
       (category: key, items: buckets[key]!)

--- a/Sources/Splint/Splint.docc/GroupedLensGuide.md
+++ b/Sources/Splint/Splint.docc/GroupedLensGuide.md
@@ -116,6 +116,28 @@ lens.refresh()
 For state you *can* observe, `.onChange(of:)` plus the matching
 `update…` method remains the right pattern — see the next section.
 
+## Aggregate-aware categorizers
+
+When a category depends on the collection as a whole — percentile
+buckets, above/below median, rank-based groups — pass a two-argument
+categorizer. It receives the current item *and* the full filtered +
+sorted collection (the same array exposed as `items`):
+
+```swift
+let lens = GroupedLens<Book, String>(
+  source: catalog,
+  categorize: { book, all in
+    let median = all.map(\.rating).sorted()[all.count / 2]
+    return book.rating >= median ? "Top half" : "Bottom half"
+  })
+```
+
+The same two-argument form is available on
+``GroupedLens/updateCategories(_:)-9y3ib``. The closure fires once per
+item in `items`, not once per item in the source — filter runs first.
+Passing a one-argument closure (or `nil`) still works via the simpler
+overloads; Swift picks the right one based on the closure's arity.
+
 ## Closures capture once
 
 ``GroupedLens`` captures `filter`, `sort`, and `categorize` at init.

--- a/Tests/SplintTests/GroupedLensLargeNTests.swift
+++ b/Tests/SplintTests/GroupedLensLargeNTests.swift
@@ -82,6 +82,22 @@ struct GroupedLensLargeNTests {
     #expect(counter.value - afterInit == 500, "updateSort's refresh must invoke categorize exactly once per filtered item, not 2×")
   }
 
+  @Test func twoArgCategorizerInvokedOncePerFilteredItem() async {
+    let c = await loadedCatalog(makeItems(n))
+    let counter = LockCounter()
+
+    let l = GroupedLens<TestItem, Int>(
+      source: c,
+      filter: { $0.score >= 500 },
+      categorize: { item, _ in
+        counter.increment()
+        return item.score % 10
+      }
+    )
+    _ = l
+    #expect(counter.value == 500, "two-arg categorize must fire exactly once per filtered item")
+  }
+
   @Test func groupingDoesNotDegradeSortStability() async {
     // Within a group, items should appear in the lens's sort order.
     // Here: ascending by id (the default when no sort, since Catalog

--- a/Tests/SplintTests/GroupedLensTests.swift
+++ b/Tests/SplintTests/GroupedLensTests.swift
@@ -203,6 +203,75 @@ struct GroupedLensTests {
     #expect(l.groups.map(\.category) == ["a", "b", "c"])
   }
 
+  @Test func aggregateCategorizerSeesFilteredAndSortedItems() async {
+    let c = await loadedCatalog(sample)
+    let seen = MutableBox<[[Int]]>(value: [])
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      filter: { $0.score >= 5 },
+      sort: { $0.score < $1.score },
+      categorize: { _, all in
+        seen.value.append(all.map(\.score))
+        return "x"
+      }
+    )
+    _ = l
+    // One call per filtered item; each call receives the same
+    // filtered+sorted collection the lens has already computed.
+    #expect(seen.value.count == 3)
+    #expect(seen.value.allSatisfy { $0 == [5, 7, 9] })
+  }
+
+  @Test func aggregateCategorizerBucketsRelativeToAllItems() async {
+    let c = await loadedCatalog(sample)
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      categorize: { item, all in
+        let median = all.map(\.score).sorted()[all.count / 2]
+        return item.score >= median ? "high" : "low"
+      }
+    )
+    // scores: [5, 9, 1, 7] → sorted [1, 5, 7, 9]; count 4, median index 2 → 7.
+    // high (>=7): apple (9), apricot (7). low: banana (5), cherry (1).
+    let high = l.groups.first { $0.category == "high" }?.items.map(\.id).sorted()
+    let low = l.groups.first { $0.category == "low" }?.items.map(\.id).sorted()
+    #expect(high == [2, 4])
+    #expect(low == [1, 3])
+  }
+
+  @Test func updateCategoriesTwoArgOverloadRecomputesGroups() async {
+    let c = await loadedCatalog(sample)
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      categorize: { $0.name.prefix(1).lowercased() }
+    )
+    #expect(l.groups.map(\.category) == ["a", "b", "c"])
+    l.updateCategories { item, all in
+      let mean = Double(all.map(\.score).reduce(0, +)) / Double(all.count)
+      return Double(item.score) >= mean ? "high" : "low"
+    }
+    // mean = 22/4 = 5.5 → high: 9, 7; low: 5, 1
+    let high = l.groups.first { $0.category == "high" }?.items.map(\.id).sorted()
+    let low = l.groups.first { $0.category == "low" }?.items.map(\.id).sorted()
+    #expect(high == [2, 4])
+    #expect(low == [1, 3])
+  }
+
+  @Test func updateCategoriesNilClearsAfterTwoArgCategorizer() async {
+    let c = await loadedCatalog(sample)
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      categorize: { item, all in
+        let mean = Double(all.map(\.score).reduce(0, +)) / Double(all.count)
+        return Double(item.score) >= mean ? "high" : "low"
+      }
+    )
+    #expect(!l.groups.isEmpty)
+    l.updateCategories(nil)
+    #expect(l.groups.isEmpty)
+    #expect(!l.items.isEmpty)
+  }
+
   @Test func clearsWhenSourceClearsOnCriteriaChange() async {
     let counter = Counter()
     let c = Catalog<TestItem, TestCriteria> { _ in


### PR DESCRIPTION
## Summary

- Adds a `(Item, [Item]) -> Category` overload to `GroupedLens.init` and `updateCategories(_:)` so categorizers can bucket based on aggregates (percentiles, above/below median, rank) without precomputing outside the lens.
- Existing `(Item) -> Category` form is unchanged and remains the default — internally wrapped as the two-arg form. Swift picks the right overload from the closure's arity.
- `filter`/`sort` intentionally left alone: filter has a weak use case (revisit later), sort has none (comparators are inherently pairwise).

## Contract

The `[Item]` passed to the closure is the **filtered + sorted** collection (same array as `items`) — filter runs first, then sort, then categorize. Documented in the DocC guide.

## Test plan

- [x] New tests in `GroupedLensTests.swift`:
  - closure receives the filtered+sorted array
  - median-bucketing at init
  - switching one-arg → two-arg via `updateCategories`
  - `updateCategories(nil)` clears groups after a two-arg categorizer
- [x] New counter test in `GroupedLensLargeNTests.swift` verifying two-arg categorize is invoked exactly once per filtered item
- [x] `./script/test` passes; 100% line coverage on `Sources/Splint/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)