### PR TITLE
Source-aware `categorize` overload on `GroupedLens`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `GroupedLens` categorizer overload that receives the raw source
+  collection alongside the filtered+sorted visible one:
+  `(Item, _ visible: [Item], _ source: [Item]) -> Category`. Enables
+  bucketing anchored to the source (e.g. "above the library-wide mean"
+  while the lens is filtered to a subset) without reaching outside the
+  lens. Available on both `init` and `updateCategories(_:)`; the
+  existing one- and two-argument forms are unchanged.
+
 ## [0.4.0] - 2026-04-24
 
 ### Added

--- a/Sources/Splint/GroupedLens.swift
+++ b/Sources/Splint/GroupedLens.swift
@@ -39,7 +39,7 @@ public final class GroupedLens<
   @ObservationIgnored private let sourceItems: @MainActor () -> [Item]
   @ObservationIgnored private var filter: @Sendable (Item) -> Bool
   @ObservationIgnored private var order: (@Sendable (Item, Item) -> Bool)?
-  @ObservationIgnored private var categorize: (@Sendable (Item, [Item]) -> Category)?
+  @ObservationIgnored private var categorize: (@Sendable (Item, [Item], [Item]) -> Category)?
 
   public init<Criteria: Equatable & Sendable>(
     source: Catalog<Item, Criteria>,
@@ -66,8 +66,8 @@ public final class GroupedLens<
     self.sourceItems = { source.items }
     self.filter = filter
     self.order = sort
-    self.categorize = categorize.map { simple -> @Sendable (Item, [Item]) -> Category in
-      { item, _ in simple(item) }
+    self.categorize = categorize.map { simple -> @Sendable (Item, [Item], [Item]) -> Category in
+      { item, _, _ in simple(item) }
     }
     refresh()
     observe()
@@ -76,13 +76,34 @@ public final class GroupedLens<
   /// Aggregate-aware variant. The categorizer receives the current item
   /// *and* the full filtered+sorted collection, enabling bucketing that
   /// depends on aggregates (percentiles, above/below median, rank).
-  /// `all` is the same array exposed as ``items``; it has already had
-  /// `filter` and `sort` applied.
+  /// `visible` is the same array exposed as ``items``; it has already
+  /// had `filter` and `sort` applied. Use the three-argument overload
+  /// when aggregates should be computed from the raw source instead.
   public init<Criteria: Equatable & Sendable>(
     source: Catalog<Item, Criteria>,
     filter: @escaping @Sendable (Item) -> Bool = { _ in true },
     sort: (@Sendable (Item, Item) -> Bool)? = nil,
-    categorize: @escaping @Sendable (Item, [Item]) -> Category
+    categorize: @escaping @Sendable (_ item: Item, _ visible: [Item]) -> Category
+  ) {
+    self.sourceItems = { source.items }
+    self.filter = filter
+    self.order = sort
+    self.categorize = { item, visible, _ in categorize(item, visible) }
+    refresh()
+    observe()
+  }
+
+  /// Source-aware variant. The categorizer receives the current item,
+  /// the filtered+sorted `visible` collection (same as ``items``), and
+  /// the raw `source` collection from the catalog (before filtering or
+  /// sorting). Use when bucketing must be anchored to the source — e.g.
+  /// "above the library-wide mean" while the lens is filtered to a
+  /// subset.
+  public init<Criteria: Equatable & Sendable>(
+    source: Catalog<Item, Criteria>,
+    filter: @escaping @Sendable (Item) -> Bool = { _ in true },
+    sort: (@Sendable (Item, Item) -> Bool)? = nil,
+    categorize: @escaping @Sendable (_ item: Item, _ visible: [Item], _ source: [Item]) -> Category
   ) {
     self.sourceItems = { source.items }
     self.filter = filter
@@ -108,15 +129,28 @@ public final class GroupedLens<
   /// Replace the categorizer and recompute. Pass `nil` to clear
   /// ``groups`` back to empty without losing ``items``.
   public func updateCategories(_ categorize: (@Sendable (Item) -> Category)?) {
-    self.categorize = categorize.map { simple -> @Sendable (Item, [Item]) -> Category in
-      { item, _ in simple(item) }
+    self.categorize = categorize.map { simple -> @Sendable (Item, [Item], [Item]) -> Category in
+      { item, _, _ in simple(item) }
     }
     refresh()
   }
 
   /// Aggregate-aware variant of ``updateCategories(_:)``. The closure
-  /// receives the current item and the full filtered+sorted collection.
-  public func updateCategories(_ categorize: @escaping @Sendable (Item, [Item]) -> Category) {
+  /// receives the current item and the filtered+sorted `visible`
+  /// collection (same as ``items``).
+  public func updateCategories(
+    _ categorize: @escaping @Sendable (_ item: Item, _ visible: [Item]) -> Category
+  ) {
+    self.categorize = { item, visible, _ in categorize(item, visible) }
+    refresh()
+  }
+
+  /// Source-aware variant of ``updateCategories(_:)``. The closure
+  /// receives the current item, the filtered+sorted `visible`
+  /// collection, and the raw `source` collection from the catalog.
+  public func updateCategories(
+    _ categorize: @escaping @Sendable (_ item: Item, _ visible: [Item], _ source: [Item]) -> Category
+  ) {
     self.categorize = categorize
     refresh()
   }
@@ -134,7 +168,8 @@ public final class GroupedLens<
   /// recomputed. For state you *can* observe, `.onChange(of:)` plus
   /// the matching `update…` method remains the right pattern.
   public func refresh() {
-    var result = sourceItems().filter(self.filter)
+    let source = sourceItems()
+    var result = source.filter(self.filter)
     if let order { result.sort(by: order) }
     items = result
 
@@ -144,7 +179,7 @@ public final class GroupedLens<
     }
     var buckets: [Category: [Item]] = [:]
     for item in result {
-      buckets[categorize(item, result), default: []].append(item)
+      buckets[categorize(item, result, source), default: []].append(item)
     }
     groups = buckets.keys.sorted().map { key in
       (category: key, items: buckets[key]!)

--- a/Sources/Splint/Splint.docc/GroupedLensGuide.md
+++ b/Sources/Splint/Splint.docc/GroupedLensGuide.md
@@ -121,22 +121,50 @@ For state you *can* observe, `.onChange(of:)` plus the matching
 When a category depends on the collection as a whole — percentile
 buckets, above/below median, rank-based groups — pass a two-argument
 categorizer. It receives the current item *and* the full filtered +
-sorted collection (the same array exposed as `items`):
+sorted `visible` collection (the same array exposed as `items`):
 
 ```swift
 let lens = GroupedLens<Book, String>(
   source: catalog,
-  categorize: { book, all in
-    let median = all.map(\.rating).sorted()[all.count / 2]
+  categorize: { book, visible in
+    let median = visible.map(\.rating).sorted()[visible.count / 2]
     return book.rating >= median ? "Top half" : "Bottom half"
   })
 ```
 
-The same two-argument form is available on
-``GroupedLens/updateCategories(_:)-9y3ib``. The closure fires once per
-item in `items`, not once per item in the source — filter runs first.
-Passing a one-argument closure (or `nil`) still works via the simpler
-overloads; Swift picks the right one based on the closure's arity.
+The closure fires once per item in `items`, not once per item in the
+source — filter runs first. Passing a one-argument closure (or `nil`)
+still works via the simpler overload; Swift picks the right one based
+on the closure's arity.
+
+### Bucketing against the raw source
+
+Sometimes a category should be anchored to the *source* collection,
+not the filtered-and-sorted visible one — for example, "above the
+library-wide mean" while the lens is filtered to a single genre. A
+three-argument categorizer receives the raw source array as well:
+
+```swift
+let lens = GroupedLens<Book, String>(
+  source: catalog,
+  filter: { $0.genre == .mystery },
+  categorize: { book, _, source in
+    let libraryMean = Double(source.map(\.rating).reduce(0, +))
+      / Double(source.count)
+    return Double(book.rating) >= libraryMean ? "Above avg" : "Below avg"
+  })
+```
+
+The parameters are **positional**:
+
+1. `item` — the current item.
+2. `visible` — the filtered + sorted array (same as `items`).
+3. `source` — the raw catalog items, before filter or sort.
+
+Pick the overload that matches your aggregate's scope: visible for
+"top half of what's on screen", source for "ranked within the whole
+library". The one- and two-argument forms both remain available; all
+three variants exist on ``GroupedLens/updateCategories(_:)-9y3ib`` too.
 
 ## Closures capture once
 

--- a/Tests/SplintTests/GroupedLensLargeNTests.swift
+++ b/Tests/SplintTests/GroupedLensLargeNTests.swift
@@ -98,6 +98,22 @@ struct GroupedLensLargeNTests {
     #expect(counter.value == 500, "two-arg categorize must fire exactly once per filtered item")
   }
 
+  @Test func threeArgCategorizerInvokedOncePerFilteredItem() async {
+    let c = await loadedCatalog(makeItems(n))
+    let counter = LockCounter()
+
+    let l = GroupedLens<TestItem, Int>(
+      source: c,
+      filter: { $0.score >= 500 },
+      categorize: { item, _, _ in
+        counter.increment()
+        return item.score % 10
+      }
+    )
+    _ = l
+    #expect(counter.value == 500, "three-arg categorize must fire exactly once per filtered item")
+  }
+
   @Test func groupingDoesNotDegradeSortStability() async {
     // Within a group, items should appear in the lens's sort order.
     // Here: ascending by id (the default when no sort, since Catalog

--- a/Tests/SplintTests/GroupedLensTests.swift
+++ b/Tests/SplintTests/GroupedLensTests.swift
@@ -272,6 +272,92 @@ struct GroupedLensTests {
     #expect(!l.items.isEmpty)
   }
 
+  @Test func sourceAwareCategorizerSeesRawSourceAndFilteredVisible() async {
+    let c = await loadedCatalog(sample)
+    let seenVisible = MutableBox<[[Int]]>(value: [])
+    let seenSource = MutableBox<[[Int]]>(value: [])
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      filter: { $0.score >= 5 },
+      sort: { $0.score < $1.score },
+      categorize: { _, visible, source in
+        seenVisible.value.append(visible.map(\.score))
+        seenSource.value.append(source.map(\.score))
+        return "x"
+      }
+    )
+    _ = l
+    // One call per filtered item; visible == items (filtered+sorted),
+    // source == raw catalog items (neither filtered nor sorted).
+    #expect(seenVisible.value.count == 3)
+    #expect(seenVisible.value.allSatisfy { $0 == [5, 7, 9] })
+    #expect(seenSource.value.count == 3)
+    #expect(seenSource.value.allSatisfy { $0 == [5, 9, 1, 7] })
+  }
+
+  @Test func sourceAwareBucketingStableAcrossFilter() async {
+    let c = await loadedCatalog(sample)
+    // Source mean = (5+9+1+7)/4 = 5.5 → high: 9, 7 ; low: 5, 1.
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      categorize: { item, _, source in
+        let mean = Double(source.map(\.score).reduce(0, +)) / Double(source.count)
+        return Double(item.score) >= mean ? "high" : "low"
+      }
+    )
+    // Baseline: full source visible.
+    #expect(
+      l.groups.first { $0.category == "high" }?.items.map(\.id).sorted() == [2, 4]
+    )
+    #expect(
+      l.groups.first { $0.category == "low" }?.items.map(\.id).sorted() == [1, 3]
+    )
+    // Filter to just the three highest-scoring items. Buckets must
+    // stay anchored to the *source* mean, so item 1 (score 5) remains
+    // "low" even though it's now the lowest *visible* score.
+    l.updateFilter { $0.score >= 5 }
+    #expect(
+      l.groups.first { $0.category == "high" }?.items.map(\.id).sorted() == [2, 4]
+    )
+    #expect(
+      l.groups.first { $0.category == "low" }?.items.map(\.id) == [1]
+    )
+  }
+
+  @Test func updateCategoriesThreeArgOverloadRecomputesGroups() async {
+    let c = await loadedCatalog(sample)
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      categorize: { $0.name.prefix(1).lowercased() }
+    )
+    #expect(l.groups.map(\.category) == ["a", "b", "c"])
+    l.updateCategories { item, _, source in
+      let mean = Double(source.map(\.score).reduce(0, +)) / Double(source.count)
+      return Double(item.score) >= mean ? "high" : "low"
+    }
+    #expect(
+      l.groups.first { $0.category == "high" }?.items.map(\.id).sorted() == [2, 4]
+    )
+    #expect(
+      l.groups.first { $0.category == "low" }?.items.map(\.id).sorted() == [1, 3]
+    )
+  }
+
+  @Test func updateCategoriesNilClearsAfterThreeArgCategorizer() async {
+    let c = await loadedCatalog(sample)
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      categorize: { item, _, source in
+        let mean = Double(source.map(\.score).reduce(0, +)) / Double(source.count)
+        return Double(item.score) >= mean ? "high" : "low"
+      }
+    )
+    #expect(!l.groups.isEmpty)
+    l.updateCategories(nil)
+    #expect(l.groups.isEmpty)
+    #expect(!l.items.isEmpty)
+  }
+
   @Test func clearsWhenSourceClearsOnCriteriaChange() async {
     let counter = Counter()
     let c = Catalog<TestItem, TestCriteria> { _ in


### PR DESCRIPTION
## Summary

- Adds a third `categorize` overload: `(Item, _ visible: [Item], _ source: [Item]) -> Category`. `visible` is the filtered+sorted array (same as `items`); `source` is the raw catalog items.
- Lets categorizers bucket relative to the source rather than the filtered view — e.g. "above the library-wide mean" while the lens is filtered to a subset. Previously required capturing `catalog.items` outside the lens and keeping it coherent with `refresh()`.
- Storage normalizes to the three-arg form; the one- and two-arg overloads wrap it. All three variants exist on both `init` and `updateCategories(_:)`. Swift disambiguates on closure arity.

## Design notes

- **Positional params.** `(item, visible, source)` — relying on DocC + parameter labels on the public signature rather than introducing a `CategorizeContext<Item>` struct. Keeps the API shape consistent with the existing two-arg form.
- No deprecation; additive only.
- `filter`/`sort` intentionally left alone.

## Test plan

- [x] `sourceAwareCategorizerSeesRawSourceAndFilteredVisible` — both arrays have the right contract
- [x] `sourceAwareBucketingStableAcrossFilter` — bucket assignment stays anchored to source after `updateFilter`
- [x] `updateCategoriesThreeArgOverloadRecomputesGroups`
- [x] `updateCategoriesNilClearsAfterThreeArgCategorizer`
- [x] `threeArgCategorizerInvokedOncePerFilteredItem` at n=1000
- [x] `./script/test` passes; 100% line coverage on `Sources/Splint/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)