### PR TITLE
Add NoCriteria seeded convenience init (closes #37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `Catalog<Item, NoCriteria>.init(initialItems:fetch:)` — seeded form of
+  the parameter-free convenience init. Combines `initialItems:`
+  (cache-first / disk-snapshot) with the existing parameter-free
+  `init(fetch:)` so cache-first parameter-free catalogs avoid dropping
+  back to the base init's `_ in` placeholder
+  ([#37](https://github.com/searlsco/splint/issues/37)).
+
 ## [0.6.1] - 2026-04-27
 
 ### Added

--- a/Sources/Splint/Catalog.swift
+++ b/Sources/Splint/Catalog.swift
@@ -81,6 +81,10 @@ public final class Catalog<Item: Resource, Criteria: Equatable & Sendable> {
     }
   }
 
+  /// When `Criteria == NoCriteria`, prefer the convenience overloads on
+  /// ``NoCriteria`` that drop the unused criteria from the fetch
+  /// signature.
+  ///
   /// - Parameters:
   ///   - initialItems: A seed populating ``items`` before any fetch. Use
   ///     this to show a cached/snapshot copy on cold launch so consumers
@@ -160,6 +164,14 @@ extension Catalog where Criteria == NoCriteria {
   /// Convenience init for parameter-free catalogs.
   public convenience init(fetch: @escaping @Sendable () async throws -> [Item]) {
     self.init { _ in try await fetch() }
+  }
+
+  /// Convenience init for parameter-free catalogs with a seed.
+  public convenience init(
+    initialItems: [Item],
+    fetch: @escaping @Sendable () async throws -> [Item]
+  ) {
+    self.init(initialItems: initialItems) { _ in try await fetch() }
   }
 
   /// Load with no criteria.

--- a/Tests/SplintTests/CatalogTests.swift
+++ b/Tests/SplintTests/CatalogTests.swift
@@ -240,6 +240,19 @@ struct CatalogTests {
     #expect(c.items.count == 1)
   }
 
+  @Test func noCriteriaConvenienceAcceptsInitialItems() async {
+    let seed = [TestItem(id: 1, name: "seed", score: 0)]
+    let fresh = [TestItem(id: 2, name: "fresh", score: 1)]
+    let c = Catalog<TestItem, NoCriteria>(initialItems: seed) {
+      fresh
+    }
+    // Seed is visible before any load.
+    #expect(c.items == seed)
+    c.load()
+    await waitUntil { c.phase == .completed }
+    #expect(c.items == fresh)
+  }
+
   @Test func awaitSettledWaitsForInFlightLoad() async {
     let gate = AsyncGate()
     let c = Catalog<TestItem, TestCriteria> { _ in


### PR DESCRIPTION
## Summary

- Adds `Catalog<Item, NoCriteria>.init(initialItems:fetch:)` so cache-first parameter-free catalogs can pair `initialItems:` (disk-snapshot / cold-launch seed) with the existing parameter-free `init(fetch:)` instead of dropping back to the base init's `_ in` placeholder.
- Cross-links from the base `init(initialItems:fetch:)` doc comment to the `NoCriteria` convenience overloads — prose rather than a `<doc:>` link, since DocC overload disambiguation is fragile.
- `[Unreleased]` CHANGELOG entry referencing #37.

Closes [#37](https://github.com/searlsco/splint/issues/37).

## Test plan

- [x] New `noCriteriaConvenienceAcceptsInitialItems` test asserts seed visible pre-load and replaced post-load — verified red→green (the test fails to compile without the new overload because Swift binds the trailing closure to the base init's `(NoCriteria) -> [Item]` type).
- [x] `script/test_fast` — 119 tests pass.
- [x] `script/test` — full suite passes; 100% coverage gate clean across `Sources/Splint/`.
- [x] `script/lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)