### PR TITLE
Allow @MainActor primitives as EnvironmentKey defaults (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `Selection<ID>.init()` (parameterless) and `Job<Value>.init()` are now
+  `nonisolated`, allowing construction from any actor context. This lets
+  these primitives be used as the `defaultValue` of a SwiftUI
+  `EnvironmentKey`, which is read from nonisolated contexts. Property
+  reads and writes on these types remain `@MainActor`-isolated; only
+  parameterless construction is loosened.
+
+  `Selection`'s previous combined initializer
+  `init(_ initial: ID? = nil)` is split into a `nonisolated init()`
+  and an unchanged `@MainActor init(_ initial: ID?)`. Existing call
+  sites — `Selection<X>()`, `Selection<X>("seed")`,
+  `Selection<X>(nil)` — continue to compile without modification
+  ([#39](https://github.com/searlsco/splint/issues/39)).
+
+  Not in this release: seeded `Selection` construction
+  (`Selection<X>("seed")`) and `Setting` construction remain
+  `@MainActor`. Both initializers write to `@Observable` stored
+  properties, which the Swift 6 compiler treats as
+  main-actor-isolated even from `init` bodies; relaxing them would
+  require dropping `@MainActor` from the type or a
+  `nonisolated(unsafe)` workaround, neither of which preserves the
+  property-access guardrail.
+
 ## [0.7.0] - 2026-04-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- `Selection<ID>.init()` (parameterless) and `Job<Value>.init()` are now
-  `nonisolated`, allowing construction from any actor context. This lets
-  these primitives be used as the `defaultValue` of a SwiftUI
-  `EnvironmentKey`, which is read from nonisolated contexts. Property
-  reads and writes on these types remain `@MainActor`-isolated; only
-  parameterless construction is loosened.
+- Enables `Selection<ID>()` and `Job<Value>()` as
+  `EnvironmentKey.defaultValue` in projects using Splint primitives in
+  SwiftUI environment values. `Selection<ID>.init()` (parameterless)
+  and `Job<Value>.init()` are now `nonisolated`, allowing construction
+  from any actor context (`EnvironmentKey.defaultValue` is a
+  nonisolated protocol requirement). Property reads and writes on
+  these types remain `@MainActor`-isolated; only parameterless
+  construction is loosened.
 
   `Selection`'s previous combined initializer
   `init(_ initial: ID? = nil)` is split into a `nonisolated init()`

--- a/Sources/Splint/Job.swift
+++ b/Sources/Splint/Job.swift
@@ -27,7 +27,10 @@ public final class Job<Value: Sendable> {
   @_spi(Internal)
   public var currentTask: Task<Void, Never>? { runningTask }
 
-  public init() {}
+  /// Construction is `nonisolated`; property reads and writes remain
+  /// `@MainActor`. This lets `Job` be used as the `defaultValue` of a
+  /// SwiftUI `EnvironmentKey`, which is read from nonisolated contexts.
+  public nonisolated init() {}
 
   /// Run an async operation, transferring its result into the Job's
   /// ``value``.

--- a/Sources/Splint/Selection.swift
+++ b/Sources/Splint/Selection.swift
@@ -11,8 +11,16 @@ public final class Selection<ID: Hashable & Sendable> {
   /// The currently selected identifier, or `nil` if nothing is selected.
   public var current: ID?
 
-  /// Create a selection with an optional initial value.
-  public init(_ initial: ID? = nil) {
+  /// Create an empty selection.
+  ///
+  /// Construction is `nonisolated`; property reads and writes remain
+  /// `@MainActor`. This lets `Selection` be used as the
+  /// `defaultValue` of a SwiftUI `EnvironmentKey`, which is read from
+  /// nonisolated contexts.
+  public nonisolated init() {}
+
+  /// Create a selection seeded with an initial value.
+  public init(_ initial: ID?) {
     self.current = initial
   }
 }

--- a/Tests/SplintTests/NonisolatedConstructionTests.swift
+++ b/Tests/SplintTests/NonisolatedConstructionTests.swift
@@ -21,4 +21,15 @@ struct NonisolatedConstructionTests {
     let job = Job<Int>()
     _ = job
   }
+
+  // Deliberately not covered, by design — both initializers write to
+  // a non-`@ObservationIgnored` `@Observable` stored property, which the
+  // Swift 6 compiler treats as `@MainActor`-isolated even from init
+  // bodies. Relaxing them would require dropping `@MainActor` from the
+  // type or introducing `nonisolated(unsafe)` storage; both sacrifice
+  // the property-access guardrail. See CHANGELOG and #39 for context.
+  //
+  //   Selection<ID>.init(_ initial: ID?)
+  //   Setting<Value>.init(_:default:store:)
+  //   Setting<Value>.init(_:default:store:read:write:)  // @_spi(Internal)
 }

--- a/Tests/SplintTests/NonisolatedConstructionTests.swift
+++ b/Tests/SplintTests/NonisolatedConstructionTests.swift
@@ -1,0 +1,24 @@
+import Testing
+
+@testable import Splint
+
+/// Compilation success IS the contract: this suite is intentionally NOT
+/// `@MainActor`-isolated, so any `init` it calls must be `nonisolated`.
+/// If a covered type's `init` regresses to main-actor isolation, this
+/// file fails to build — which is what proves the guarantee.
+///
+/// Property reads on the constructed instances would require re-entering
+/// the main actor; this suite does not exercise them. The point is the
+/// init call site, not post-init behavior (covered by the per-type suites).
+@Suite("Nonisolated construction")
+struct NonisolatedConstructionTests {
+  @Test func selectionConstructsFromNonisolatedContext() {
+    let selection = Selection<String>()
+    _ = selection
+  }
+
+  @Test func jobConstructsFromNonisolatedContext() {
+    let job = Job<Int>()
+    _ = job
+  }
+}


### PR DESCRIPTION
## Summary

Resolves #39 — `Selection<ID>` and `Job<Value>` can now be used as the
`defaultValue` of a SwiftUI `EnvironmentKey`.

- `Selection<ID>.init()` (parameterless) and `Job<Value>.init()` are now
  `nonisolated`. Property reads/writes on both types stay
  `@MainActor`-isolated; only construction is loosened.
- `Selection`'s previous `init(_ initial: ID? = nil)` is split into a
  `nonisolated init()` and an unchanged `@MainActor init(_ initial: ID?)`.
  Existing call sites — `Selection<X>()`, `Selection<X>("seed")`,
  `Selection<X>(nil)` — continue to compile without modification.

### Plan deviation worth flagging

The original plan assumed the `@Observable` macro's storage-init
accessor (`@storageRestrictions(initializes: _current)`) would let
nonisolated init bodies write to `@Observable` properties directly.
The Swift 6 compiler rejects this — `self.observableProp = x` in a
nonisolated init on a `@MainActor` class is treated as a main-actor
setter call regardless of the storage accessor. Confirmed
empirically; not a Swift bug, just a stricter rule than the plan
expected.

Adapted in flight:

- For `Selection`, split the init so the parameterless case (the
  actual env-default sweet spot per #39) gets `nonisolated`.
- For seeded `Selection<X>("seed")` and `Setting`, kept `@MainActor`
  per the plan's pre-authorized fallback. Documented in CHANGELOG and
  in the test file's trailing comment.

## Test plan

- [x] `script/test_fast` — 121 tests pass.
- [x] `script/test` — full suite + 100% line coverage gate on
  \`Sources/Splint/\`.
- [x] `script/lint` — clean.
- [x] New `NonisolatedConstructionTests.swift` is intentionally
  **not** `@MainActor`. Compilation success IS the contract — if a
  covered init regresses to main-actor isolation, the file fails to
  build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)