### PR TITLE
Make subscript(id:) O(1) on Catalog, add it to Lens and GroupedLens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `Catalog.subscript(id:)` is now O(1). The previous implementation
+  was a linear scan over `items`; in selection-driven SwiftUI code a
+  single body evaluation can resolve "which item is selected right
+  now" several times across child views (sidebar, content, detail) on
+  every keystroke, every `.onChange`, every selection transition that
+  observers care about. The catalog now maintains a private id-keyed
+  dictionary, rebuilt whenever `items` is reassigned, so id lookups
+  are constant time. Behavior on duplicate ids is preserved — when
+  multiple items share an id, the first occurrence wins, matching
+  the prior `items.first { $0.id == id }` semantics
+  ([#42](https://github.com/searlsco/splint/issues/42)).
+
+### Added
+
+- `Lens.subscript(id:)` and `GroupedLens.subscript(id:)` — O(1) id
+  lookup over the lens's filtered projection. An item present in the
+  source catalog but excluded by `filter` returns `nil`, matching the
+  intuitive reading: a lens reports what it shows. Same first-wins
+  semantics on duplicate ids as `Catalog`.
+
 ## [0.7.1] - 2026-05-02
 
 ## [0.7.1] - 2026-05-02

--- a/Sources/Splint/Catalog.swift
+++ b/Sources/Splint/Catalog.swift
@@ -28,7 +28,9 @@ public final class Catalog<Item: Resource, Criteria: Equatable & Sendable> {
   /// the current non-nil criteria; preserved across a first load (so
   /// seeded items stay visible until the first fetch completes) and
   /// across ``refresh()``.
-  public private(set) var items: [Item] = []
+  public private(set) var items: [Item] = [] {
+    didSet { rebuildItemsByID() }
+  }
   /// The criteria used for the most recent (or in-flight) load.
   public private(set) var criteria: Criteria?
   /// Fetch lifecycle phase.
@@ -39,6 +41,7 @@ public final class Catalog<Item: Resource, Criteria: Equatable & Sendable> {
   @ObservationIgnored private let fetch: @Sendable (Criteria) async throws -> [Item]
   @ObservationIgnored private var task: Task<Void, Never>?
   @ObservationIgnored private var fetchGeneration: UInt64 = 0
+  @ObservationIgnored private var itemsByID: [Item.ID: Item] = [:]
 
   /// Underlying task for the most recent fetch. Exposed under
   /// `@_spi(Internal)` so tests can assert on Task identity (e.g. that
@@ -102,6 +105,9 @@ public final class Catalog<Item: Resource, Criteria: Equatable & Sendable> {
   ) {
     self.items = initialItems
     self.fetch = fetch
+    // Property observers (didSet) do not fire for assignments inside an
+    // init body, so seed the index manually after the stored property is set.
+    rebuildItemsByID()
   }
 
   /// Load with `criteria`. If `criteria` differs from an existing non-nil
@@ -132,10 +138,16 @@ public final class Catalog<Item: Resource, Criteria: Equatable & Sendable> {
     refresh()
   }
 
-  /// Find an item by id. Convenience for detail views receiving an id from
-  /// navigation.
+  /// Find an item by id. O(1). Convenience for detail views receiving an id
+  /// from navigation. When ``items`` contains multiple entries with the same
+  /// id, the first occurrence wins.
   public subscript(id id: Item.ID) -> Item? {
-    items.first { $0.id == id }
+    _ = items
+    return itemsByID[id]
+  }
+
+  private func rebuildItemsByID() {
+    itemsByID = Dictionary(items.lazy.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
   }
 
   private func performFetch(_ criteria: Criteria) {

--- a/Sources/Splint/GroupedLens.swift
+++ b/Sources/Splint/GroupedLens.swift
@@ -29,7 +29,9 @@ public final class GroupedLens<
 > {
   /// The filtered and sorted projection of the source. Always
   /// populated, regardless of whether a categorizer is set.
-  public private(set) var items: [Item] = []
+  public private(set) var items: [Item] = [] {
+    didSet { rebuildItemsByID() }
+  }
 
   /// The grouped projection, ordered by `Category`'s `Comparable`.
   /// Empty when ``updateCategories(_:)`` has not been called or was
@@ -40,6 +42,7 @@ public final class GroupedLens<
   @ObservationIgnored private var filter: @Sendable (Item) -> Bool
   @ObservationIgnored private var order: (@Sendable (Item, Item) -> Bool)?
   @ObservationIgnored private var categorize: (@Sendable (Item, [Item], [Item]) -> Category)?
+  @ObservationIgnored private var itemsByID: [Item.ID: Item] = [:]
 
   public init<Criteria: Equatable & Sendable>(
     source: Catalog<Item, Criteria>,
@@ -184,6 +187,20 @@ public final class GroupedLens<
     groups = buckets.keys.sorted().map { key in
       (category: key, items: buckets[key]!)
     }
+  }
+
+  /// Find an item by id within the lens's filtered projection. O(1).
+  /// Returns `nil` if `id` is not present in ``items`` after filtering —
+  /// even if it exists in the source catalog. When the projection
+  /// contains multiple entries with the same id, the first occurrence
+  /// wins.
+  public subscript(id id: Item.ID) -> Item? {
+    _ = items
+    return itemsByID[id]
+  }
+
+  private func rebuildItemsByID() {
+    itemsByID = Dictionary(items.lazy.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
   }
 
   private func observe() {

--- a/Sources/Splint/Lens.swift
+++ b/Sources/Splint/Lens.swift
@@ -16,11 +16,14 @@ import Observation
 @MainActor
 public final class Lens<Item: Resource> {
   /// The filtered and sorted projection of the source.
-  public private(set) var items: [Item] = []
+  public private(set) var items: [Item] = [] {
+    didSet { rebuildItemsByID() }
+  }
 
   @ObservationIgnored private let sourceItems: @MainActor () -> [Item]
   @ObservationIgnored private var filter: @Sendable (Item) -> Bool
   @ObservationIgnored private var order: (@Sendable (Item, Item) -> Bool)?
+  @ObservationIgnored private var itemsByID: [Item.ID: Item] = [:]
   public init<Criteria: Equatable & Sendable>(
     source: Catalog<Item, Criteria>,
     /// Predicate applied to each item. Captured once at init; re-runs only
@@ -70,6 +73,20 @@ public final class Lens<Item: Resource> {
     var result = sourceItems().filter(self.filter)
     if let order { result.sort(by: order) }
     items = result
+  }
+
+  /// Find an item by id within the lens's filtered projection. O(1).
+  /// Returns `nil` if `id` is not present in ``items`` after filtering —
+  /// even if it exists in the source catalog. When the projection
+  /// contains multiple entries with the same id, the first occurrence
+  /// wins.
+  public subscript(id id: Item.ID) -> Item? {
+    _ = items
+    return itemsByID[id]
+  }
+
+  private func rebuildItemsByID() {
+    itemsByID = Dictionary(items.lazy.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
   }
 
   private func observe() {

--- a/Tests/SplintTests/CatalogTests.swift
+++ b/Tests/SplintTests/CatalogTests.swift
@@ -187,6 +187,68 @@ struct CatalogTests {
     #expect(c[id: 99] == nil)
   }
 
+  @Test func subscriptReflectsItemsAfterRefresh() async {
+    let counter = Counter()
+    let c = Catalog<TestItem, TestCriteria> { _ in
+      let n = await counter.increment()
+      return n == 1
+        ? [TestItem(id: 1, name: "first", score: 1)]
+        : [TestItem(id: 2, name: "second", score: 2)]
+    }
+    c.load(TestCriteria(category: "x"))
+    await waitUntil { c.phase == .completed }
+    #expect(c[id: 1]?.name == "first")
+    #expect(c[id: 2] == nil)
+    c.refresh()
+    await waitUntil { c.items.first?.id == 2 }
+    #expect(c[id: 1] == nil)
+    #expect(c[id: 2]?.name == "second")
+  }
+
+  @Test func subscriptReturnsNilAfterCriteriaChangeClearsItems() async {
+    let gate = AsyncGate()
+    let counter = Counter()
+    let c = Catalog<TestItem, TestCriteria> { _ in
+      let n = await counter.increment()
+      if n > 1 { await gate.wait() }
+      return [TestItem(id: n, name: "X", score: n)]
+    }
+    c.load(TestCriteria(category: "a"))
+    await waitUntil { c.phase == .completed }
+    #expect(c[id: 1]?.name == "X")
+    c.load(TestCriteria(category: "b"))
+    // Criteria change clears items synchronously; subscript must follow.
+    #expect(c[id: 1] == nil)
+    await gate.open()
+    await waitUntil { c.phase == .completed && !c.items.isEmpty }
+    #expect(c[id: 2]?.name == "X")
+  }
+
+  @Test func subscriptHonorsSeededInitialItems() {
+    let seed = [
+      TestItem(id: 1, name: "seed-a", score: 0),
+      TestItem(id: 2, name: "seed-b", score: 0),
+    ]
+    let c = Catalog<TestItem, TestCriteria>(initialItems: seed) { _ in [] }
+    // Subscript must work before any load() — the seed populates the index.
+    #expect(c[id: 1]?.name == "seed-a")
+    #expect(c[id: 2]?.name == "seed-b")
+    #expect(c[id: 99] == nil)
+  }
+
+  @Test func subscriptKeepsFirstOccurrenceForDuplicateIDs() async {
+    let c = Catalog<TestItem, TestCriteria> { _ in
+      [
+        TestItem(id: 1, name: "first", score: 1),
+        TestItem(id: 1, name: "second", score: 2),
+      ]
+    }
+    c.load(TestCriteria(category: "x"))
+    await waitUntil { c.phase == .completed }
+    // Matches today's items.first { $0.id == id } semantics.
+    #expect(c[id: 1]?.name == "first")
+  }
+
   @Test func initialItemsSeedsItemsBeforeAnyLoad() {
     let seed = [TestItem(id: 1, name: "seed", score: 0)]
     let c = Catalog<TestItem, TestCriteria>(initialItems: seed) { _ in [] }

--- a/Tests/SplintTests/GroupedLensTests.swift
+++ b/Tests/SplintTests/GroupedLensTests.swift
@@ -358,6 +358,68 @@ struct GroupedLensTests {
     #expect(!l.items.isEmpty)
   }
 
+  @Test func subscriptReturnsMatchingItem() async {
+    let c = await loadedCatalog(sample)
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      categorize: { $0.name.prefix(1).lowercased() }
+    )
+    #expect(l[id: 1]?.name == "banana")
+    #expect(l[id: 99] == nil)
+  }
+
+  @Test func subscriptReturnsNilForFilteredOutItem() async {
+    let c = await loadedCatalog(sample)
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      filter: { $0.score >= 5 },
+      categorize: { $0.name.prefix(1).lowercased() }
+    )
+    // cherry (id 3, score 1) is in the source but filtered out.
+    #expect(l[id: 1]?.name == "banana")
+    #expect(l[id: 3] == nil)
+  }
+
+  @Test func subscriptReflectsSourceChange() async {
+    let counter = Counter()
+    let c = Catalog<TestItem, TestCriteria> { _ in
+      let n = await counter.increment()
+      return [TestItem(id: n, name: "x", score: n)]
+    }
+    c.load(TestCriteria(category: "a"))
+    await waitUntil { c.phase == .completed }
+    let l = GroupedLens<TestItem, Int>(source: c, categorize: { $0.score })
+    await waitUntil { l[id: 1] != nil }
+    #expect(l[id: 1]?.score == 1)
+    #expect(l[id: 2] == nil)
+    c.refresh()
+    await waitUntil { l[id: 2] != nil }
+    #expect(l[id: 1] == nil)
+    #expect(l[id: 2]?.score == 2)
+  }
+
+  @Test func subscriptReflectsFilterUpdate() async {
+    let c = await loadedCatalog(sample)
+    let l = GroupedLens<TestItem, String>(
+      source: c,
+      categorize: { $0.name.prefix(1).lowercased() }
+    )
+    #expect(l[id: 3]?.name == "cherry")
+    l.updateFilter { $0.score >= 5 }
+    #expect(l[id: 3] == nil)
+    l.updateFilter { _ in true }
+    #expect(l[id: 3]?.name == "cherry")
+  }
+
+  @Test func subscriptKeepsFirstOccurrenceForDuplicateIDs() async {
+    let c = await loadedCatalog([
+      TestItem(id: 1, name: "first", score: 1),
+      TestItem(id: 1, name: "second", score: 2),
+    ])
+    let l = GroupedLens<TestItem, Int>(source: c, categorize: { $0.score })
+    #expect(l[id: 1]?.name == "first")
+  }
+
   @Test func clearsWhenSourceClearsOnCriteriaChange() async {
     let counter = Counter()
     let c = Catalog<TestItem, TestCriteria> { _ in

--- a/Tests/SplintTests/LensTests.swift
+++ b/Tests/SplintTests/LensTests.swift
@@ -124,6 +124,61 @@ struct LensTests {
     #expect(l.items.map(\.score) == [9, 5, 1])
   }
 
+  @Test func subscriptReturnsMatchingItem() async {
+    let c = await loadedCatalog(sample)
+    let l = Lens<TestItem>(source: c)
+    #expect(l[id: 1]?.name == "banana")
+    #expect(l[id: 99] == nil)
+  }
+
+  @Test func subscriptReturnsNilForFilteredOutItem() async {
+    let c = await loadedCatalog(sample)
+    let l = Lens<TestItem>(source: c, filter: { $0.score >= 5 })
+    // cherry (id 3, score 1) is in the source but filtered out.
+    #expect(l[id: 1]?.name == "banana")
+    #expect(l[id: 2]?.name == "apple")
+    #expect(l[id: 3] == nil)
+  }
+
+  @Test func subscriptReflectsSourceChange() async {
+    let counter = Counter()
+    let c = Catalog<TestItem, TestCriteria> { _ in
+      let n = await counter.increment()
+      return [TestItem(id: n, name: "x", score: n)]
+    }
+    c.load(TestCriteria(category: "a"))
+    await waitUntil { c.phase == .completed }
+    let l = Lens<TestItem>(source: c)
+    await waitUntil { l[id: 1] != nil }
+    #expect(l[id: 1]?.score == 1)
+    #expect(l[id: 2] == nil)
+    c.refresh()
+    await waitUntil { l[id: 2] != nil }
+    #expect(l[id: 1] == nil)
+    #expect(l[id: 2]?.score == 2)
+  }
+
+  @Test func subscriptReflectsFilterUpdate() async {
+    let c = await loadedCatalog(sample)
+    let l = Lens<TestItem>(source: c)
+    #expect(l[id: 3]?.name == "cherry")
+    l.updateFilter { $0.score >= 5 }
+    #expect(l[id: 3] == nil)
+    l.updateFilter { _ in true }
+    #expect(l[id: 3]?.name == "cherry")
+  }
+
+  @Test func subscriptKeepsFirstOccurrenceForDuplicateIDs() async {
+    // Two items share id 1; lens should surface the first one — same
+    // semantics as Catalog's items.first { $0.id == id }.
+    let c = await loadedCatalog([
+      TestItem(id: 1, name: "first", score: 1),
+      TestItem(id: 1, name: "second", score: 2),
+    ])
+    let l = Lens<TestItem>(source: c)
+    #expect(l[id: 1]?.name == "first")
+  }
+
   @Test func clearsWhenSourceClearsOnCriteriaChange() async {
     // First load populates.
     let counter = Counter()


### PR DESCRIPTION
## Summary

Resolves [#42](https://github.com/searlsco/splint/issues/42).

`Catalog.subscript(id:)` was an O(n) linear scan over `items`. In selection-driven SwiftUI code a single body evaluation can resolve "which item is selected right now" several times across child views (sidebar, content, detail) on every keystroke, every `.onChange`, every selection transition that observers care about — the cost of the scan amplifies under high-churn observation.

Each of the three sequence-of-`Resource` types now keeps a private `@ObservationIgnored` `Dictionary<Item.ID, Item>` rebuilt via `didSet` on `items`. Subscripts read `_ = items` first so observers register on the public source of truth, then look up via the dict — O(1).

- `Catalog.subscript(id:)` is now O(1) (was O(n)).
- New `Lens.subscript(id:)` and `GroupedLens.subscript(id:)` returning items from the lens's filtered projection (an item filtered out returns nil even if present in the source).
- Duplicate-id behavior preserved: first occurrence wins, matching the prior `items.first { \$0.id == id }` semantics.

## Notes for reviewers

- `didSet` does not fire for assignments inside an init body, so `Catalog.init(initialItems:)` calls `rebuildItemsByID()` explicitly after seeding. Lens/GroupedLens inits call `refresh()` (a method call), where `didSet` does fire — verified by the new `subscriptReturnsMatchingItem` tests, which exercise the subscript immediately after construction with no async wait.
- `@Observable` + `didSet` is an existing pattern in this codebase ([Setting.swift:21-29](https://github.com/searlsco/splint/blob/main/Sources/Splint/Setting.swift#L21-L29)).
- The dict is `@ObservationIgnored` so the cache is invisible to the observation system; `items` remains the only observed signal.

## Test plan

- [x] `swift test` — all 145 tests pass.
- [x] `script/test` — full suite + 100% line coverage gate on \`Sources/Splint/\` (Catalog 67/67, Lens 43/43, GroupedLens 92/92).
- [x] `script/lint` — clean.
- [x] New tests in [CatalogTests.swift](https://github.com/searlsco/splint/blob/claude/compassionate-visvesvaraya-ecfef1/Tests/SplintTests/CatalogTests.swift), [LensTests.swift](https://github.com/searlsco/splint/blob/claude/compassionate-visvesvaraya-ecfef1/Tests/SplintTests/LensTests.swift), [GroupedLensTests.swift](https://github.com/searlsco/splint/blob/claude/compassionate-visvesvaraya-ecfef1/Tests/SplintTests/GroupedLensTests.swift) cover: refresh reflection, post-clear nil, seeded subscript, filter exclusion (Lens/GroupedLens), filter-update reflection, and duplicate-id first-wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)