### PR TITLE
Document subscript[id:] as the preferred id-lookup primitive

### DIFF
--- a/claude/rules/splint.md
+++ b/claude/rules/splint.md
@@ -41,6 +41,16 @@ inventing a new type.
 Pair with SwiftUI: `.task(id: channel.id) { catalog.load(...) }` gives
 you free cancellation when the id changes.
 
+## Looking up by id
+
+Use `catalog[id: id]` / `lens[id: id]` / `groupedLens[id: id]` — never
+`.items.first(where: { $0.id == id })`. The subscript is O(1) (backed
+by a private id index), and on `Lens` / `GroupedLens` it respects the
+filter — an item filtered out returns `nil` even if the source has
+it, which is almost always what call sites want. Duplicate ids
+resolve to the first occurrence, matching the linear-scan semantics
+it replaces.
+
 ## Catalog lifecycle
 
 Every catalog is `@State` on the narrowest view that fully contains its


### PR DESCRIPTION
## Summary

0.8.0 shipped O(1) `subscript[id:]` on `Catalog`, `Lens`, and `GroupedLens` (#43), but the rules doc still implies users should hand-write `.items.first(where: { \$0.id == id })`. Without a mention in the rules file, downstream users naturally reach for the linear-scan idiom — exactly what the PR was designed to obsolete.

This adds a short section to `claude/rules/splint.md` (between `load(_:) vs refresh()` and `Catalog lifecycle`) telling readers:

- Use `catalog[id: id]` / `lens[id: id]` / `groupedLens[id: id]` — never `.items.first(where:)`.
- It's O(1).
- On `Lens` / `GroupedLens`, a filtered-out item returns `nil` (which is almost always what call sites want).
- Duplicate ids resolve to first-occurrence-wins, matching the prior linear-scan semantics.

Drafted in the voice of the existing sections (rule first, brief why, no code example needed for a trivial subscript surface).

## Test plan

- [x] Doc-only change — no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)